### PR TITLE
slider.prev() instead of the global scope search

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -167,7 +167,7 @@
                 slider[0].style.display = "none";
                 slider.before(containerHTML);
 
-                var $container = $("#irs-" + this.pluginCount),
+                var $container = slider.prev(),
                     $body = $(document.body),
                     $window = $(window),
                     $rangeSlider,


### PR DESCRIPTION
Select $container not from the document, but get the previously inserted span element. This is useful when rendering the widget into the shadowed DOM/Document Fragment.
