### PR TITLE
Bugfix: the type of data attributes is string even if they contain a numeric value

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -178,16 +178,16 @@
 
 
                 // extend from data-*
-                if (typeof slider.data("min") === "number") {
+                if (typeof parseFloat(slider.data("min")) === "number") {
                     settings.min = parseFloat(slider.data("min"));
                 }
-                if (typeof slider.data("max") === "number") {
+                if (typeof parseFloat(slider.data("max")) === "number") {
                     settings.max = parseFloat(slider.data("max"));
                 }
-                if (typeof slider.data("from") === "number") {
+                if (typeof parseFloat(slider.data("from")) === "number") {
                     settings.from = parseFloat(slider.data("from"));
                 }
-                if (typeof slider.data("to") === "number") {
+                if (typeof parseFloat(slider.data("to")) === "number") {
                     settings.to = parseFloat(slider.data("to"));
                 }
                 if (slider.data("step")) {


### PR DESCRIPTION
The type of data attribute is string so if you write the following code:

```
console.log(typeof $("#slider").data("min")); // this will print "string"
```

so the existing code would not work. I have updated the code to parse the data attributes not as strings but as numeric values.
