### PR TITLE
Add jquery dependency to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,9 @@
             "homepage": "http://ionden.com"
         }
     ],
+    "dependencies": {
+        "jquery": ">=1.9"
+    },
     "description": "Powerful range slider with skin support",
     "repository": {
         "type": "git",


### PR DESCRIPTION
This is necessary for tools like `wiredep` to correctly order jquery before ion.rangeSlider.
