### PR TITLE
Adds "onBegin" event

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -257,6 +257,7 @@
             disable: false,
 
             onStart: null,
+            onBegin: null,
             onChange: null,
             onFinish: null,
             onUpdate: null
@@ -579,6 +580,11 @@
             }
 
             this.$cache.line.trigger("focus");
+
+            if (this.options.onBegin && typeof this.options.onBegin === "function") {
+                    this.options.onBegin(this.result);
+            }
+
         },
 
         pointerClick: function (target, e) {


### PR DESCRIPTION
I may be missing something, but it appears that the `onStart` event is really an `onInit` event as it only runs when the rangeSlider is initialized.  The `onFinish` fires after the mouseup event, so it would be logical to have onStart fired on the mousedown event.

This PR adds a new event `onBegin` that will be triggered in the `pointerDown` function.  This way you can respond to when the range selection starts (`onBegin`) and when it ends (`onFinish`).  The naming is a little awkward, but this prevents introducing a breaking change.

