### PR TITLE
Chaining sliders on drag

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -825,6 +825,10 @@
                     break;
 
                 case "both":
+                    if (this.options.from_fixed || this.options.to_fixed) {
+                        break;
+                    }
+
                     real_x = this.toFixed(real_x + (this.coords.p_handle * 0.1));
 
                     this.coords.p_from_real = this.calcWithStep((real_x - this.coords.p_gap_left) / real_width * 100);

--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -191,7 +191,9 @@
             step: $inp.data("step"),
 
             min_interval: $inp.data("minInterval"),
+            min_interval_chain: $inp.data("minIntervalChain"),
             max_interval: $inp.data("maxInterval"),
+            max_interval_chain: $inp.data("maxIntervalChain"),
             drag_interval: $inp.data("dragInterval"),
 
             values: $inp.data("values"),
@@ -265,7 +267,9 @@
             step: 1,
 
             min_interval: 0,
+            min_interval_chain: false,
             max_interval: 0,
+            max_interval_chain: false,
             drag_interval: false,
 
             values: [],
@@ -793,6 +797,7 @@
                     break;
 
                 case "from":
+                    var realMinInterval, realMaxInterval;
                     if (this.options.from_fixed) {
                         break;
                     }
@@ -802,13 +807,31 @@
                         this.coords.p_from_real = this.coords.p_to_real;
                     }
                     this.coords.p_from_real = this.checkDiapason(this.coords.p_from_real, this.options.from_min, this.options.from_max);
+
+                    // Check for keeping the "to" close by
+                    if (this.options.min_interval && this.options.min_interval_chain === true) {
+                        realMinInterval = this.calcPercent(this.options.min + this.options.min_interval);
+                        this.coords.p_to_real = Math.max(this.coords.p_from_real + realMinInterval, this.coords.p_to_real);
+                        this.coords.p_to_real = Math.min(this.coords.p_to_real, 100);
+                    }
+
+                    // Check for keeping the "to" far away
+                    if (this.options.max_interval && this.options.max_interval_chain === true) {
+                        realMaxInterval = this.calcPercent(this.options.min + this.options.max_interval);
+                        this.coords.p_to_real = Math.min(this.coords.p_from_real + realMaxInterval, this.coords.p_to_real);
+                    }
+                    // Update the "to", although it might not have changed.
+                    this.coords.p_to = this.toFixed(this.coords.p_to_real / 100 * real_width);
+
                     this.coords.p_from_real = this.checkMinInterval(this.coords.p_from_real, this.coords.p_to_real, "from");
                     this.coords.p_from_real = this.checkMaxInterval(this.coords.p_from_real, this.coords.p_to_real, "from");
+
                     this.coords.p_from = this.toFixed(this.coords.p_from_real / 100 * real_width);
 
                     break;
 
                 case "to":
+                    var realMinInterval, realMaxInterval;
                     if (this.options.to_fixed) {
                         break;
                     }
@@ -818,8 +841,23 @@
                         this.coords.p_to_real = this.coords.p_from_real;
                     }
                     this.coords.p_to_real = this.checkDiapason(this.coords.p_to_real, this.options.to_min, this.options.to_max);
+
+                    // Check for keeping the "from" close by
+                    if (this.options.min_interval && this.options.min_interval_chain === true) {
+                        realMinInterval = this.calcPercent(this.options.min + this.options.min_interval);
+                        this.coords.p_from_real = Math.min(this.coords.p_to_real - realMinInterval, this.coords.p_from_real);
+                    }
+                    // Check for keeping the "from" far away
+                    if (this.options.max_interval && this.options.max_interval_chain === true) {
+                        realMaxInterval = this.calcPercent(this.options.min + this.options.max_interval);
+                        this.coords.p_from_real = Math.max(0, this.coords.p_to_real - realMaxInterval, this.coords.p_from_real);
+                    }
+                    // Update the "from", although it might not have changed.
+                    this.coords.p_from = this.toFixed(this.coords.p_from_real / 100 * real_width);
+
                     this.coords.p_to_real = this.checkMinInterval(this.coords.p_to_real, this.coords.p_from_real, "to");
                     this.coords.p_to_real = this.checkMaxInterval(this.coords.p_to_real, this.coords.p_from_real, "to");
+
                     this.coords.p_to = this.toFixed(this.coords.p_to_real / 100 * real_width);
 
                     break;

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > English description | <a href="readme.ru.md">Описание на русском</a>
 
-Easy and light range slider
+Easy and light weight range slider
 * <a href="http://ionden.com/a/plugins/ion.rangeSlider/en.html">Project page and demos</a>
 * <a href="http://ionden.com/a/plugins/ion.rangeSlider/ion.rangeSlider-2.0.6.zip">Download ion.rangeSlider-2.0.6.zip</a>
 
@@ -27,14 +27,14 @@ Easy and light range slider
 * Support of custom values diapason
 * Customisable grid of values
 * Ability to disable UI elements (min and max, current value, grid)
-* Postfixes and prefixes for you numbers ($20, 20 &euro; etc.)
+* Postfixes and prefixes for your numbers ($20, 20 &euro; etc.)
 * Additional postfix for maximum value (eg. $0 — $100<b>+</b>)
 * Ability to prettify large numbers (eg. 10000000 -> 10 000 000 or 10.000.000)
-* Slider writes it's value right into input value field. This makes it easy to use in any html form
+* Slider writes its value right into input value field. This makes it easy to use in any html form
 * Any slider value can be set through input data-attribute (eg. data-min="10")
 * Slider supports disable param. You can set it true to make slider inactive
 * Slider supports external methods (update, reset and remove) to control it after creation
-* For advanced users slider has callbacks (onStart, onChange, onFinish, onUpdate). Slider paste all it's params to callback first argument as object
+* For advanced users slider has callbacks (onStart, onChange, onFinish, onUpdate). Slider pastes all its params to callback first argument as object
 * Slider supports date and time
 
 
@@ -100,7 +100,7 @@ $("#example_id").ionRangeSlider();
 
 ## Demo for juniors
 
-If your are new person in web development and you are not sure how to correctly install the plugin to your web-page, please download
+If your are new in web development and you are not sure how to correctly install the plugin to your web-page, please download
 <a href="http://ionden.com/a/plugins/ion.rangeSlider/ionRangeSliderDemo.zip" class="button">this demo example</a>
 
 
@@ -130,7 +130,7 @@ If your are new person in web development and you are not sure how to correctly 
             <td>type<div><sup>data-type</sup></div></td>
             <td>"single"</td>
             <td>string</td>
-            <td>Choose slider type, could be <code>single</code> - for one handle, or <code>double</code> four two handles</td>
+            <td>Choose slider type, could be <code>single</code> - for one handle, or <code>double</code> for two handles</td>
         </tr>
 
         <tr>


### PR DESCRIPTION
### Description
This adds a new feature to the min and max intervals to allow dragging the slider beyond the max/min interval and just push or pull the other slider to stay in the valid range.
This also incorporates my other pull request with text change and a minor fix in drag_interval. Which becomes obsolete if this one is used.

### Defaults
Default are set to the original behaviour.
* min_interval_chain : false
* max_interval_chain : false

### Todo
* Clean up the code a bit, split it up inside its own function. I had to build this quickly and it wasn't easy to figure out what all variables meant without code comments.

### Demo
[Demo old and new behaviour](http://geuze.name/basement/projects/ionrangeslider/)