### PR TITLE
Fix: grid label collisions for force_edges == true (issue #226)

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -1726,15 +1726,15 @@
             }
 
             if (this.options.force_edges) {
-                if (start[0] < this.coords.grid_gap) {
-                    start[0] = this.coords.grid_gap;
+                if (start[0] < -this.coords.grid_gap) {
+                    start[0] = -this.coords.grid_gap;
                     finish[0] = this.toFixed(start[0] + this.coords.big_p[0]);
 
                     this.coords.big_x[0] = this.coords.grid_gap;
                 }
 
-                if (finish[num - 1] > 100 - this.coords.grid_gap) {
-                    finish[num - 1] = 100 - this.coords.grid_gap;
+                if (finish[num - 1] > 100 + this.coords.grid_gap) {
+                    finish[num - 1] = 100 + this.coords.grid_gap;
                     start[num - 1] = this.toFixed(finish[num - 1] - this.coords.big_p[num - 1]);
 
                     this.coords.big_x[num - 1] = this.toFixed(this.coords.big_p[num - 1] - this.coords.grid_gap);


### PR DESCRIPTION
The spacing to the sides of the grid ('grid_gap') sits **outside** the grid div (achieved via _width_ and _left_ on .irs-grid), so when calculating the positions of the end labels for collisions it needs to be treated as such. Currently it is assumed to sit _inside_ the grid div, and hence there are cases where a label is hidden when in reality there is no need.

See issue #226 for more details.