### PR TITLE
Handle selection

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -892,9 +892,9 @@
             } else {
                 var m_point = this.coords.p_from_real + ((this.coords.p_to_real - this.coords.p_from_real) / 2);
                 if (real_x >= m_point) {
-                    return "to";
+                    return this.options.to_fixed ? "from" : "to";
                 } else {
-                    return "from";
+                    return this.options.from_fixed ? "to" : "from";
                 }
             }
         },


### PR DESCRIPTION
As you can see in this [example](http://jsfiddle.net/7ode0efk/). Clicking the slider bar any where below half the distance between `from` and `to` (< 50%) does nothing because `from` handle is fixed.
