### PR TITLE
fix name for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-    "name": "ion.rangeSlider",
+    "name": "ion.rangeslider",
     "version": "2.0.12",
     "homepage": "https://github.com/IonDen/ion.rangeSlider",
     "authors": [


### PR DESCRIPTION
bower ion.rangeSlider#2.0.12                     extract archive.tar.gz
bower ion.rangeSlider#2.0.12                    EINVALID Failed to read /var/folders/1t/y1l91wl10c1dzz3682wqvnxh0000gn/T/moi/bower/ion.rangeSlider-16116-Lo4AXL/bower.json

Additional error details:
The name contains upper case letters


see https://github.com/bower/bower.json-spec#name