### PR TITLE
Allow customizing grid

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -325,7 +325,8 @@
             onStart: null,
             onChange: null,
             onFinish: null,
-            onUpdate: null
+            onUpdate: null,
+            onLabelClick: null
         }, options);
 
         this.validate();
@@ -512,6 +513,8 @@
             this.$cache.win.off("touchend.irs_" + this.plugin_count);
             this.$cache.win.off("mouseup.irs_" + this.plugin_count);
 
+            this.$cache.grid.off("click");
+
             if (is_old_ie) {
                 this.$cache.body.off("mouseup.irs_" + this.plugin_count);
                 this.$cache.body.off("mouseleave.irs_" + this.plugin_count);
@@ -535,6 +538,11 @@
 
             this.$cache.line.on("touchstart.irs_" + this.plugin_count, this.pointerClick.bind(this, "click"));
             this.$cache.line.on("mousedown.irs_" + this.plugin_count, this.pointerClick.bind(this, "click"));
+
+            var that = this;
+            this.$cache.grid.on("click", ".irs-grid-text", function(event) {
+                that._onLabelClick(event, $(this).data('result'));
+            });
 
             if (this.options.drag_interval && this.options.type === "double") {
                 this.$cache.bar.on("touchstart.irs_" + this.plugin_count, this.pointerDown.bind(this, "both"));
@@ -1523,6 +1531,12 @@
             return this._prettify(num);
         },
 
+        _onLabelClick: function (event, result) {
+            if (this.options.onLabelClick && typeof this.options.onLabelClick === "function") {
+                this.options.onLabelClick(this.$cache.input.data('ionRangeSlider'), event, +result);
+            }
+        },
+
         _additionalGridLineClass: function (num) {
             if (this.options.additional_grid_line_class && typeof this.options.additional_grid_line_class === "function") {
                 return this.options.additional_grid_line_class(num);
@@ -1840,7 +1854,7 @@
 
                 // Do not render blank labels to improve performance
                 if (result && result.length) {
-                    html += '<span class="irs-grid-text js-grid-text-' + i + '" style="left: ' + big_w + '%">' + result + '</span>';
+                    html += '<span class="irs-grid-text js-grid-text-' + i + '" style="left: ' + big_w + '%" data-result="' + this.calcReal(big_w) + '">' + result + '</span>';
                 }
             }
             this.coords.big_num = Math.ceil(big_num + 1);

--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -298,6 +298,8 @@
             prettify: null,
 
             prettify_labels: null,
+            additional_grid_line_class: null,
+            grid_line_visible: null,
 
             force_edges: false,
 
@@ -1521,6 +1523,20 @@
             return this._prettify(num);
         },
 
+        _additionalGridLineClass: function (num) {
+            if (this.options.additional_grid_line_class && typeof this.options.additional_grid_line_class === "function") {
+                return this.options.additional_grid_line_class(num);
+            }
+        },
+
+        _gridLineVisible: function (num) {
+            if (this.options.grid_line_visible && typeof this.options.grid_line_visible === "function") {
+                return this.options.grid_line_visible(num);
+            } else {
+                return true;
+            }
+        },
+
         checkEdges: function (left, width) {
             if (!this.options.force_edges) {
                 return this.toFixed(left);
@@ -1810,9 +1826,12 @@
                     html += '<span class="irs-grid-pol small" style="left: ' + small_w + '%"></span>';
                 }
 
-                html += '<span class="irs-grid-pol" style="left: ' + big_w + '%"></span>';
-
                 result = this.calcReal(big_w);
+
+                if (this._gridLineVisible(result)) {
+                    html += '<span class="irs-grid-pol ' + this._additionalGridLineClass(result) + '" style="left: ' + big_w + '%"></span>';
+                }
+
                 if (o.values.length) {
                     result = o.p_values[result];
                 } else {


### PR DESCRIPTION
Hi,

When using ion.rangeSlider for the date slider in our project, we find that we need more customization abilities that the library doesn't have yet. This PR adds the ability to customize those aspects that we think people are likely to want for their project. With this users can:

1. Customize grid label format based on their values (different from the overall value format via `prettify` that is showing in drag handle, min/max values, ...)
2. Add callback for when users click on grid labels.
3. Customize visibility & appearance of grid lines based on their values

Example usage can be seen in this fiddle: http://jsfiddle.net/maxwueqm/ where:

1. Grid labels display month names.
2. Clicking on each month label selects the corresponding range
3. Grid lines (ticks) are shown only on month start & middle values. The tick at the middle of each month is shorter than the one at the start of the month because it has a custom 'small' class

Please note that we need `grid_snap: true` for this to work.
