### PR TITLE
Add customizable top grid (to show labels above slider)

### DIFF
--- a/css/ion.rangeSlider.css
+++ b/css/ion.rangeSlider.css
@@ -89,7 +89,17 @@
     bottom: 0; left: 0;
     width: 100%; height: 20px;
 }
-.irs-with-grid .irs-grid {
+
+.irs-top-grid {
+    position: absolute; display: none;
+    bottom: 0; left: 0;
+    width: 100%;
+    top: 0;
+    height: 16px;
+}
+
+.irs-with-grid .irs-grid,
+.irs-with-grid .irs-top-grid {
     display: block;
 }
     .irs-grid-pol {
@@ -101,7 +111,8 @@
     .irs-grid-pol.small {
         height: 4px;
     }
-    .irs-grid-text {
+    .irs-grid-text,
+    .irs-top-grid-text {
         position: absolute;
         bottom: 0; left: 0;
         white-space: nowrap;

--- a/css/ion.rangeSlider.skinFlat.css
+++ b/css/ion.rangeSlider.skinFlat.css
@@ -102,5 +102,15 @@
     color: #999;
 }
 
+.irs-top-grid-text {
+    color: #999;
+    font-size: 10px; line-height: 1.333;
+    text-shadow: none;
+    top: 0; padding: 1px 3px;
+    background: #e1e4e9;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+}
+
 .irs-disabled {
 }

--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -111,6 +111,7 @@
 
     var base_html =
         '<span class="irs">' +
+        '<span class="irs-top-grid"></span>' +
         '<span class="irs-line" tabindex="-1"><span class="irs-line-left"></span><span class="irs-line-mid"></span><span class="irs-line-right"></span></span>' +
         '<span class="irs-min">0</span><span class="irs-max">1</span>' +
         '<span class="irs-from">0</span><span class="irs-to">0</span><span class="irs-single">0</span>' +
@@ -186,7 +187,8 @@
             shad_to: null,
             edge: null,
             grid: null,
-            grid_labels: []
+            grid_labels: [],
+            top_grid_labels: []
         };
 
         // get config data attributes
@@ -307,6 +309,10 @@
             grid_num: 4,
             grid_snap: false,
 
+            top_grid: false,
+            prettifyTopGridLabels: null,
+            topGridLabelVisible: null,
+
             hide_min_max: false,
             hide_from_to: false,
 
@@ -321,7 +327,8 @@
             onStart: null,
             onChange: null,
             onFinish: null,
-            onUpdate: null
+            onUpdate: null,
+            onTopLabelClick: null
         }, options);
 
         this.validate();
@@ -374,7 +381,10 @@
             big: [],
             big_w: [],
             big_p: [],
-            big_x: []
+            big_x: [],
+            top_label_big_w: [],
+            top_label_big_p: [],
+            top_label_big_x: []
         };
 
         this.labels = {
@@ -442,6 +452,7 @@
             this.$cache.bar = this.$cache.cont.find(".irs-bar");
             this.$cache.line = this.$cache.cont.find(".irs-line");
             this.$cache.grid = this.$cache.cont.find(".irs-grid");
+            this.$cache.top_grid = this.$cache.cont.find(".irs-top-grid");
 
             if (this.options.type === "single") {
                 this.$cache.cont.append(single_html);
@@ -508,6 +519,8 @@
             this.$cache.win.off("touchend.irs_" + this.plugin_count);
             this.$cache.win.off("mouseup.irs_" + this.plugin_count);
 
+            this.$cache.top_grid.off("click");
+
             if (is_old_ie) {
                 this.$cache.body.off("mouseup.irs_" + this.plugin_count);
                 this.$cache.body.off("mouseleave.irs_" + this.plugin_count);
@@ -518,6 +531,11 @@
             this.coords.big_w = [];
             this.coords.big_p = [];
             this.coords.big_x = [];
+
+            this.$cache.top_grid_labels = [];
+            this.coords.top_label_big_w = [];
+            this.coords.top_label_big_p = [];
+            this.coords.top_label_big_x = [];
 
             cancelAnimationFrame(this.raf_id);
         },
@@ -531,6 +549,11 @@
 
             this.$cache.line.on("touchstart.irs_" + this.plugin_count, this.pointerClick.bind(this, "click"));
             this.$cache.line.on("mousedown.irs_" + this.plugin_count, this.pointerClick.bind(this, "click"));
+
+            var that = this;
+            this.$cache.top_grid.on("click", ".irs-top-grid-text", function(event) {
+                that._onTopGridLabelClick(event, $(this).data('result'));
+            });
 
             if (this.options.drag_interval && this.options.type === "double") {
                 this.$cache.bar.on("touchstart.irs_" + this.plugin_count, this.pointerDown.bind(this, "both"));
@@ -1511,6 +1534,28 @@
             return n.replace(/(\d{1,3}(?=(?:\d\d\d)+(?!\d)))/g, "$1" + this.options.prettify_separator);
         },
 
+        _prettifyTopGridLabels: function (num) {
+            if (this.options.prettifyTopGridLabels && typeof this.options.prettifyTopGridLabels === "function") {
+                return this.options.prettifyTopGridLabels(num);
+            }
+
+            return this._prettify(num);
+        },
+
+        _topGridLabelVisible: function (num) {
+            if (this.options.topGridLabelVisible && typeof this.options.topGridLabelVisible === "function") {
+                return this.options.topGridLabelVisible(num);
+            }
+
+            return false;
+        },
+
+        _onTopGridLabelClick: function (event, result) {
+            if (this.options.onTopGridLabelClick && typeof this.options.onTopGridLabelClick === "function") {
+                this.options.onTopGridLabelClick(this.$cache.input.data('ionRangeSlider'), event, +result);
+            }
+        },
+
         checkEdges: function (left, width) {
             if (!this.options.force_edges) {
                 return this.toFixed(left);
@@ -1803,6 +1848,13 @@
                 html += '<span class="irs-grid-pol" style="left: ' + big_w + '%"></span>';
 
                 result = this.calcReal(big_w);
+
+                if (this.options.top_grid && this._topGridLabelVisible(result)) {
+                    var label = $('<span class="irs-top-grid-text js-top-grid-text-' + i + '" style="left: ' + big_w + '%"' + '>' + this._prettifyTopGridLabels(result) + '</span>');
+                    label.data('result', result);
+                    this.$cache.top_grid.prepend(label);
+                }
+
                 if (o.values.length) {
                     result = o.p_values[result];
                 } else {
@@ -1821,12 +1873,15 @@
         },
 
         cacheGridLabels: function () {
-            var $label, i,
+            var $label, $top_grid_label, i,
                 num = this.coords.big_num;
 
             for (i = 0; i < num; i++) {
                 $label = this.$cache.grid.find(".js-grid-text-" + i);
                 this.$cache.grid_labels.push($label);
+
+                $top_grid_label = this.$cache.top_grid.find(".js-top-grid-text-" + i);
+                this.$cache.top_grid_labels.push($top_grid_label);
             }
 
             this.calcGridLabels();
@@ -1834,6 +1889,7 @@
 
         calcGridLabels: function () {
             var i, label, start = [], finish = [],
+                top_grid_label, top_label_start = [], top_label_finish = [],
                 num = this.coords.big_num;
 
             for (i = 0; i < num; i++) {
@@ -1843,6 +1899,19 @@
 
                 start[i] = this.toFixed(this.coords.big[i] - this.coords.big_x[i]);
                 finish[i] = this.toFixed(start[i] + this.coords.big_p[i]);
+
+                // Top grid labels
+                if (this.$cache.top_grid_labels[i].length) {
+                  this.coords.top_label_big_w[i] = this.$cache.top_grid_labels[i].outerWidth(false);
+                  this.coords.top_label_big_p[i] = this.toFixed(this.coords.big_w[i] / this.coords.w_rs * 100);
+                  this.coords.top_label_big_x[i] = this.toFixed(this.coords.top_label_big_p[i] / 2);
+
+                  top_label_start[i] = this.toFixed(this.coords.big[i] - this.coords.top_label_big_x[i]);
+                  top_label_finish[i] = this.toFixed(top_label_start[i] + this.coords.top_label_big_p[i]);
+                } else {
+                  this.coords.top_label_big_w[i] = this.coords.top_label_big_p[i] = this.coords.top_label_big_x[i] =
+                  top_label_start[i] = top_label_finish[i] = 0;
+                }
             }
 
             if (this.options.force_edges) {
@@ -1859,20 +1928,43 @@
 
                     this.coords.big_x[num - 1] = this.toFixed(this.coords.big_p[num - 1] - this.coords.grid_gap);
                 }
+
+                // Top grid labels
+                if (top_label_start[0] < -this.coords.grid_gap) {
+                    top_label_start[0] = -this.coords.grid_gap;
+                    top_label_finish[0] = this.toFixed(top_label_start[0] + this.coords.top_label_big_p[0]);
+
+                    this.coords.top_label_big_x[0] = this.coords.grid_gap;
+                }
+
+                if (top_label_finish[num - 1] > 100 + this.coords.grid_gap) {
+                    top_label_finish[num - 1] = 100 + this.coords.grid_gap;
+                    top_label_start[num - 1] = this.toFixed(top_label_finish[num - 1] - this.coords.top_label_big_p[num - 1]);
+
+                    this.coords.top_label_big_x[num - 1] = this.toFixed(this.coords.top_label_big_p[num - 1] - this.coords.grid_gap);
+                }
             }
 
             this.calcGridCollision(2, start, finish);
             this.calcGridCollision(4, start, finish);
 
+            this.calcGridCollision(2, top_label_start, top_label_finish, true);
+            this.calcGridCollision(4, top_label_start, top_label_finish, true);
+
             for (i = 0; i < num; i++) {
                 label = this.$cache.grid_labels[i][0];
                 label.style.marginLeft = -this.coords.big_x[i] + "%";
+
+                top_grid_label = this.$cache.top_grid_labels[i][0];
+                if (top_grid_label) {
+                    top_grid_label.style.marginLeft = -this.coords.top_label_big_x[i] + "%";
+                }
             }
         },
 
         // Collisions Calc Beta
         // TODO: Refactor then have plenty of time
-        calcGridCollision: function (step, start, finish) {
+        calcGridCollision: function (step, start, finish, isTopGrid) {
             var i, next_i, label,
                 num = this.coords.big_num;
 
@@ -1882,7 +1974,13 @@
                     break;
                 }
 
-                label = this.$cache.grid_labels[next_i][0];
+                if (isTopGrid) {
+                  label = this.$cache.top_grid_labels[next_i][0];
+                } else {
+                  label = this.$cache.grid_labels[next_i][0];
+                }
+
+                if (!label) { continue; }
 
                 if (finish[i] <= start[next_i]) {
                     label.style.visibility = "visible";


### PR DESCRIPTION
Hi,

I've found another usecase where there's a need to show labels above the slider in addition to the grid labels under the slider. This PR adds the ability to let user:

1. Define when to show the labels above the slider
2. Prettify them according to their values and
3. Add click callback

Example usage: http://jsfiddle.net/o9oj5wrr/. In the example:

1. Month labels are shown in the grid region under slider
2. Quarter labels are shown above the slider
3. Clicking on quarter labels selects the corresponding range.

To enable the top grid, set `top_grid: true`. We would also want `hide_min_max: true` to avoid overlapping.