### PR TITLE
Add Reverse Option

### DIFF
--- a/css/ion.rangeSlider.css
+++ b/css/ion.rangeSlider.css
@@ -42,6 +42,9 @@
             position: absolute; display: block;
             top: 0; left: 0;
         }
+            .irs-bar-edge.reverse {
+                left:auto; right:0;
+            }
 
     .irs-shadow {
         position: absolute; display: none;

--- a/css/ion.rangeSlider.skinHTML5.css
+++ b/css/ion.rangeSlider.skinHTML5.css
@@ -48,6 +48,11 @@
         border-radius: 16px 0 0 16px;
         -moz-border-radius: 16px 0 0 16px;
     }
+        .irs-bar-edge.reverse {
+            border-width: 1px 1px 1px 0;
+            border-radius:0 16px 16px 0;
+            -moz-border-radius:0 16px 16px 0;
+        }
 
 .irs-shadow {
     height: 2px; top: 38px;

--- a/css/ion.rangeSlider.skinHTML5.css
+++ b/css/ion.rangeSlider.skinHTML5.css
@@ -49,6 +49,7 @@
         -moz-border-radius: 16px 0 0 16px;
     }
         .irs-bar-edge.reverse {
+            margin-right: 1px;
             border-width: 1px 1px 1px 0;
             border-radius:0 16px 16px 0;
             -moz-border-radius:0 16px 16px 0;

--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -867,6 +867,10 @@
          */
         moveByKey: function (right) {
             var p = this.coords.p_pointer;
+            
+            if (this.options.reverse) {
+                right = !right;
+            }
 
             if (right) {
                 p += this.options.keyboard_step;
@@ -874,7 +878,12 @@
                 p -= this.options.keyboard_step;
             }
 
-            this.coords.x_pointer = this.toFixed(this.coords.w_rs / 100 * p);
+            if (this.options.reverse) {
+                this.coords.x_pointer = this.coords.w_rs - this.toFixed(this.coords.w_rs / 100 * p);
+            } else {
+                this.coords.x_pointer = this.toFixed(this.coords.w_rs / 100 * p);
+            }
+            
             this.is_key = true;
             this.calc();
         },

--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -372,6 +372,7 @@
             input_values_separator: $inp.data("inputValuesSeparator"),
 
             disable: $inp.data("disable"),
+            
             reverse: $inp.data("reverse")
         };
         config_from_data.values = config_from_data.values && config_from_data.values.split(",");
@@ -492,10 +493,10 @@
             this.$cache.cont.html(base_html);
             this.$cache.rs = this.$cache.cont.find(".irs");
 
-            if (this.options.reverse === true) {
+            if (this.options.reverse) {
                 this.$cache.min = this.$cache.cont.find(".irs-max");
                 this.$cache.max = this.$cache.cont.find(".irs-min");
-            }else{
+            } else {
                 this.$cache.min = this.$cache.cont.find(".irs-min");
                 this.$cache.max = this.$cache.cont.find(".irs-max");
             }
@@ -509,7 +510,7 @@
 
             if (this.options.type === "single") {
                 this.$cache.cont.append(single_html);
-                this.$cache.edge = this.$cache.cont.find(".irs-bar-edge").toggleClass('reverse', this.options.reverse);
+                this.$cache.edge = this.$cache.cont.find(".irs-bar-edge")
                 this.$cache.s_single = this.$cache.cont.find(".single");
                 this.$cache.from[0].style.visibility = "hidden";
                 this.$cache.to[0].style.visibility = "hidden";
@@ -543,6 +544,10 @@
 
             if (this.options.drag_interval) {
                 this.$cache.bar[0].style.cursor = "ew-resize";
+            }
+            
+            if (this.options.type === "single") {
+                this.$cache.edge.toggleClass('reverse', this.options.reverse);
             }
         },
 
@@ -1138,7 +1143,12 @@
                 this.coords.x_pointer = this.coords.w_rs;
             }
 
-            this.coords.p_pointer = this.toFixed(this.convertToReversePercent(this.coords.x_pointer / this.coords.w_rs * 100));
+            if (this.options.reverse) {
+                this.coords.p_pointer = this.toFixed(this.convertToReversePercent(this.coords.x_pointer / this.coords.w_rs * 100));
+            } else {
+                this.coords.p_pointer = this.toFixed(this.coords.x_pointer / this.coords.w_rs * 100);
+            }
+            
         },
 
         convertToRealPercent: function (fake) {
@@ -1313,17 +1323,21 @@
             if (this.old_from !== this.result.from || this.old_to !== this.result.to || this.force_redraw || this.is_key) {
 
                 this.drawLabels();
-
-                this.$cache.bar[0].style.left = this.options.reverse ? this.convertToReversePercent(this.coords.p_bar_x) - this.coords.p_bar_w + "%"
-                                                                     : this.coords.p_bar_x + "%";
+                if (this.options.reverse) {
+                    this.$cache.bar[0].style.left = this.convertToReversePercent(this.coords.p_bar_x) - this.coords.p_bar_w + "%";
+                } else {
+                    this.$cache.bar[0].style.left = this.coords.p_bar_x + "%";
+                }
                 this.$cache.bar[0].style.width = this.coords.p_bar_w + "%";
 
                 if (this.options.type === "single") {
-                    this.$cache.s_single[0].style.left = this.options.reverse ? this.convertToReversePercent(this.coords.p_single_fake) - this.coords.p_handle + "%"
-                                                                              : this.coords.p_single_fake + "%";
-
-                    this.$cache.single[0].style.left = this.options.reverse ? this.convertToReversePercent(this.labels.p_single_left) - this.labels.p_single_fake + "%"
-                                                                            : this.labels.p_single_left + "%";
+                    if (this.options.reverse) {
+                        this.$cache.s_single[0].style.left = this.convertToReversePercent(this.coords.p_single_fake) - this.coords.p_handle + "%"
+                        this.$cache.single[0].style.left = this.convertToReversePercent(this.labels.p_single_left) - this.labels.p_single_fake + "%";
+                    } else {
+                        this.$cache.s_single[0].style.left = this.coords.p_single_fake + "%";
+                        this.$cache.single[0].style.left = this.labels.p_single_left + "%";
+                    }
 
                     if (this.options.values.length) {
                         this.$cache.input.prop("value", this.result.from_value);
@@ -1333,20 +1347,35 @@
                     this.$cache.input.data("from", this.result.from);
                 } else {
 
-                    this.$cache.s_from[0].style.left = this.options.reverse ? this.convertToReversePercent(this.coords.p_from_fake) - this.coords.p_handle + "%"
-                                                                            : this.coords.p_from_fake + "%";
-                    this.$cache.s_to[0].style.left = this.options.reverse ? this.convertToReversePercent(this.coords.p_to_fake) - this.coords.p_handle + "%"
-                                                                          : this.coords.p_to_fake + "%";
+                    if (this.options.reverse) {
+                        this.$cache.s_from[0].style.left = this.convertToReversePercent(this.coords.p_from_fake) - this.coords.p_handle + "%";                                                           
+                        this.$cache.s_to[0].style.left = this.convertToReversePercent(this.coords.p_to_fake) - this.coords.p_handle + "%";
+                    } else {
+                        this.$cache.s_from[0].style.left = this.coords.p_from_fake + "%";
+                        this.$cache.s_to[0].style.left = this.coords.p_to_fake + "%";
+                    }
+                    
                     if (this.old_from !== this.result.from || this.force_redraw) {
-                        this.$cache.from[0].style.left = this.options.reverse ? this.convertToReversePercent(this.labels.p_from_left) - this.labels.p_from_fake + "%"
-                                                                              : this.labels.p_from_left + "%";
+                        if (this.options.reverse) {
+                            this.$cache.from[0].style.left = this.convertToReversePercent(this.labels.p_from_left) - this.labels.p_from_fake + "%";
+                        } else {
+                            this.$cache.from[0].style.left = this.labels.p_from_left + "%";
+                        }
                     }
+                    
                     if (this.old_to !== this.result.to || this.force_redraw) {
-                        this.$cache.to[0].style.left = this.options.reverse ? this.convertToReversePercent(this.labels.p_to_left) - this.labels.p_to_fake +  "%"
-                                                                            : this.labels.p_to_left + "%";
+                        if (this.options.reverse) {
+                            this.$cache.to[0].style.left = this.convertToReversePercent(this.labels.p_to_left) - this.labels.p_to_fake +  "%";                                                          
+                        } else {
+                            this.$cache.to[0].style.left = this.labels.p_to_left + "%";
+                        }
                     }
-                    this.$cache.single[0].style.left = this.options.reverse ? this.convertToReversePercent(this.labels.p_single_left) - this.labels.p_single_fake + "%"
-                                                                            : this.labels.p_single_left + "%";
+                    
+                    if (this.options.reverse) {
+                        this.$cache.single[0].style.left = this.convertToReversePercent(this.labels.p_single_left) - this.labels.p_single_fake + "%";
+                    } else {
+                        this.$cache.single[0].style.left = this.labels.p_single_left + "%";
+                    }
 
                     if (this.options.values.length) {
                         this.$cache.input.prop("value", this.result.from_value + this.options.input_values_separator + this.result.to_value);
@@ -1537,7 +1566,7 @@
                     from_max = this.toFixed(from_max - (this.coords.p_handle / 100 * from_max));
                     from_min = from_min + (this.coords.p_handle / 2);
 
-                    if (this.options.reverse === true) {
+                    if (this.options.reverse) {
                         from_min = this.convertToReversePercent(from_min) - from_max;
                     }
 
@@ -1555,7 +1584,7 @@
                     from_max = this.toFixed(from_max - (this.coords.p_handle / 100 * from_max));
                     from_min = from_min + (this.coords.p_handle / 2);
 
-                    if (this.options.reverse === true) {
+                    if (this.options.reverse) {
                         from_min = this.convertToReversePercent(from_min) - from_max;
                     }
 
@@ -1573,7 +1602,7 @@
                     to_max = this.toFixed(to_max - (this.coords.p_handle / 100 * to_max));
                     to_min = to_min + (this.coords.p_handle / 2);
 
-                    if (this.options.reverse === true) {
+                    if (this.options.reverse) {
                         to_min = this.convertToReversePercent(to_min) - to_max;
                     }
 
@@ -1656,7 +1685,7 @@
          * @returns {Number} X in reverse percent
          */
         convertToReversePercent: function (value) {
-            return this.options.reverse ? this.toFixed(100 - value) : value;
+            return this.toFixed(100 - value);
         },
 
         /**
@@ -2134,11 +2163,18 @@
                     }
 
                     small_w = this.toFixed(big_w - (small_p * z));
-
-                    html += '<span class="irs-grid-pol small" style="left: ' + this.convertToReversePercent(small_w) + '%"></span>';
+                    if (this.options.reverse) {
+                        html += '<span class="irs-grid-pol small" style="left: ' + this.convertToReversePercent(small_w) + '%"></span>';
+                    } else {
+                        html += '<span class="irs-grid-pol small" style="left: ' + small_w + '%"></span>';
+                    }
                 }
 
-                html += '<span class="irs-grid-pol" style="left: ' + this.convertToReversePercent(big_w) + '%"></span>';
+                if (this.options.reverse) {
+                    html += '<span class="irs-grid-pol" style="left: ' + this.convertToReversePercent(big_w) + '%"></span>';
+                } else {
+                    html += '<span class="irs-grid-pol" style="left: ' + big_w + '%"></span>';
+                }
 
                 result = this.convertToValue(big_w);
                 if (o.values.length) {
@@ -2147,7 +2183,11 @@
                     result = this._prettify(result);
                 }
 
-                html += '<span class="irs-grid-text js-grid-text-' + i + '" style="left: ' + this.convertToReversePercent(big_w) + '%">' + result + '</span>';
+                if (this.options.reverse) {
+                    html += '<span class="irs-grid-text js-grid-text-' + i + '" style="left: ' + this.convertToReversePercent(big_w) + '%">' + result + '</span>';
+                } else {
+                    html += '<span class="irs-grid-text js-grid-text-' + i + '" style="left: ' + big_w + '%">' + result + '</span>';
+                }
             }
             this.coords.big_num = Math.ceil(big_num + 1);
 
@@ -2204,8 +2244,11 @@
 
             for (i = 0; i < num; i++) {
                 label = this.$cache.grid_labels[i][0];
-                label.style.marginLeft = this.options.reverse ? this.coords.big_x[i] - this.coords.big_p[i] + "%"
-                                                              : -this.coords.big_x[i] + "%";
+                if (this.options.reverse) {
+                    label.style.marginLeft = this.coords.big_x[i] - this.coords.big_p[i] + "%";
+                } else {
+                    label.style.marginLeft = -this.coords.big_x[i] + "%";
+                }
             }
         },
 

--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -1,4 +1,4 @@
-﻿// Ion.RangeSlider
+// Ion.RangeSlider
 // version 2.1.2 Build: 350
 // © Denis Ineshin, 2015
 // https://github.com/IonDen
@@ -311,6 +311,8 @@
 
             disable: false,
 
+            reverse: false,
+
             onStart: null,
             onChange: null,
             onFinish: null,
@@ -369,7 +371,8 @@
 
             input_values_separator: $inp.data("inputValuesSeparator"),
 
-            disable: $inp.data("disable")
+            disable: $inp.data("disable"),
+            reverse: $inp.data("reverse")
         };
         config_from_data.values = config_from_data.values && config_from_data.values.split(",");
 
@@ -488,8 +491,15 @@
 
             this.$cache.cont.html(base_html);
             this.$cache.rs = this.$cache.cont.find(".irs");
-            this.$cache.min = this.$cache.cont.find(".irs-min");
-            this.$cache.max = this.$cache.cont.find(".irs-max");
+
+            if (this.options.reverse === true) {
+                this.$cache.min = this.$cache.cont.find(".irs-max");
+                this.$cache.max = this.$cache.cont.find(".irs-min");
+            }else{
+                this.$cache.min = this.$cache.cont.find(".irs-min");
+                this.$cache.max = this.$cache.cont.find(".irs-max");
+            }
+
             this.$cache.from = this.$cache.cont.find(".irs-from");
             this.$cache.to = this.$cache.cont.find(".irs-to");
             this.$cache.single = this.$cache.cont.find(".irs-single");
@@ -499,7 +509,7 @@
 
             if (this.options.type === "single") {
                 this.$cache.cont.append(single_html);
-                this.$cache.edge = this.$cache.cont.find(".irs-bar-edge");
+                this.$cache.edge = this.$cache.cont.find(".irs-bar-edge").toggleClass('reverse', this.options.reverse);
                 this.$cache.s_single = this.$cache.cont.find(".single");
                 this.$cache.from[0].style.visibility = "hidden";
                 this.$cache.to[0].style.visibility = "hidden";
@@ -1128,7 +1138,7 @@
                 this.coords.x_pointer = this.coords.w_rs;
             }
 
-            this.coords.p_pointer = this.toFixed(this.coords.x_pointer / this.coords.w_rs * 100);
+            this.coords.p_pointer = this.toFixed(this.convertToReversePercent(this.coords.x_pointer / this.coords.w_rs * 100));
         },
 
         convertToRealPercent: function (fake) {
@@ -1304,13 +1314,16 @@
 
                 this.drawLabels();
 
-                this.$cache.bar[0].style.left = this.coords.p_bar_x + "%";
+                this.$cache.bar[0].style.left = this.options.reverse ? this.convertToReversePercent(this.coords.p_bar_x) - this.coords.p_bar_w + "%"
+                                                                     : this.coords.p_bar_x + "%";
                 this.$cache.bar[0].style.width = this.coords.p_bar_w + "%";
 
                 if (this.options.type === "single") {
-                    this.$cache.s_single[0].style.left = this.coords.p_single_fake + "%";
+                    this.$cache.s_single[0].style.left = this.options.reverse ? this.convertToReversePercent(this.coords.p_single_fake) - this.coords.p_handle + "%"
+                                                                              : this.coords.p_single_fake + "%";
 
-                    this.$cache.single[0].style.left = this.labels.p_single_left + "%";
+                    this.$cache.single[0].style.left = this.options.reverse ? this.convertToReversePercent(this.labels.p_single_left) - this.labels.p_single_fake + "%"
+                                                                            : this.labels.p_single_left + "%";
 
                     if (this.options.values.length) {
                         this.$cache.input.prop("value", this.result.from_value);
@@ -1319,17 +1332,21 @@
                     }
                     this.$cache.input.data("from", this.result.from);
                 } else {
-                    this.$cache.s_from[0].style.left = this.coords.p_from_fake + "%";
-                    this.$cache.s_to[0].style.left = this.coords.p_to_fake + "%";
 
+                    this.$cache.s_from[0].style.left = this.options.reverse ? this.convertToReversePercent(this.coords.p_from_fake) - this.coords.p_handle + "%"
+                                                                            : this.coords.p_from_fake + "%";
+                    this.$cache.s_to[0].style.left = this.options.reverse ? this.convertToReversePercent(this.coords.p_to_fake) - this.coords.p_handle + "%"
+                                                                          : this.coords.p_to_fake + "%";
                     if (this.old_from !== this.result.from || this.force_redraw) {
-                        this.$cache.from[0].style.left = this.labels.p_from_left + "%";
+                        this.$cache.from[0].style.left = this.options.reverse ? this.convertToReversePercent(this.labels.p_from_left) - this.labels.p_from_fake + "%"
+                                                                              : this.labels.p_from_left + "%";
                     }
                     if (this.old_to !== this.result.to || this.force_redraw) {
-                        this.$cache.to[0].style.left = this.labels.p_to_left + "%";
+                        this.$cache.to[0].style.left = this.options.reverse ? this.convertToReversePercent(this.labels.p_to_left) - this.labels.p_to_fake +  "%"
+                                                                            : this.labels.p_to_left + "%";
                     }
-
-                    this.$cache.single[0].style.left = this.labels.p_single_left + "%";
+                    this.$cache.single[0].style.left = this.options.reverse ? this.convertToReversePercent(this.labels.p_single_left) - this.labels.p_single_fake + "%"
+                                                                            : this.labels.p_single_left + "%";
 
                     if (this.options.values.length) {
                         this.$cache.input.prop("value", this.result.from_value + this.options.input_values_separator + this.result.to_value);
@@ -1520,6 +1537,10 @@
                     from_max = this.toFixed(from_max - (this.coords.p_handle / 100 * from_max));
                     from_min = from_min + (this.coords.p_handle / 2);
 
+                    if (this.options.reverse === true) {
+                        from_min = this.convertToReversePercent(from_min) - from_max;
+                    }
+
                     c.shad_single[0].style.display = "block";
                     c.shad_single[0].style.left = from_min + "%";
                     c.shad_single[0].style.width = from_max + "%";
@@ -1534,6 +1555,10 @@
                     from_max = this.toFixed(from_max - (this.coords.p_handle / 100 * from_max));
                     from_min = from_min + (this.coords.p_handle / 2);
 
+                    if (this.options.reverse === true) {
+                        from_min = this.convertToReversePercent(from_min) - from_max;
+                    }
+
                     c.shad_from[0].style.display = "block";
                     c.shad_from[0].style.left = from_min + "%";
                     c.shad_from[0].style.width = from_max + "%";
@@ -1547,6 +1572,10 @@
                     to_min = this.toFixed(to_min - (this.coords.p_handle / 100 * to_min));
                     to_max = this.toFixed(to_max - (this.coords.p_handle / 100 * to_max));
                     to_min = to_min + (this.coords.p_handle / 2);
+
+                    if (this.options.reverse === true) {
+                        to_min = this.convertToReversePercent(to_min) - to_max;
+                    }
 
                     c.shad_to[0].style.display = "block";
                     c.shad_to[0].style.left = to_min + "%";
@@ -1618,6 +1647,16 @@
             percent = val / one_percent;
 
             return this.toFixed(percent);
+        },
+
+        /**
+         * Convert percent to its reverse
+         *
+         * @param value {Number} X in percent
+         * @returns {Number} X in reverse percent
+         */
+        convertToReversePercent: function (value) {
+            return this.options.reverse ? this.toFixed(100 - value) : value;
         },
 
         /**
@@ -2096,10 +2135,10 @@
 
                     small_w = this.toFixed(big_w - (small_p * z));
 
-                    html += '<span class="irs-grid-pol small" style="left: ' + small_w + '%"></span>';
+                    html += '<span class="irs-grid-pol small" style="left: ' + this.convertToReversePercent(small_w) + '%"></span>';
                 }
 
-                html += '<span class="irs-grid-pol" style="left: ' + big_w + '%"></span>';
+                html += '<span class="irs-grid-pol" style="left: ' + this.convertToReversePercent(big_w) + '%"></span>';
 
                 result = this.convertToValue(big_w);
                 if (o.values.length) {
@@ -2108,7 +2147,7 @@
                     result = this._prettify(result);
                 }
 
-                html += '<span class="irs-grid-text js-grid-text-' + i + '" style="left: ' + big_w + '%">' + result + '</span>';
+                html += '<span class="irs-grid-text js-grid-text-' + i + '" style="left: ' + this.convertToReversePercent(big_w) + '%">' + result + '</span>';
             }
             this.coords.big_num = Math.ceil(big_num + 1);
 
@@ -2165,7 +2204,8 @@
 
             for (i = 0; i < num; i++) {
                 label = this.$cache.grid_labels[i][0];
-                label.style.marginLeft = -this.coords.big_x[i] + "%";
+                label.style.marginLeft = this.options.reverse ? this.coords.big_x[i] - this.coords.big_p[i] + "%"
+                                                              : -this.coords.big_x[i] + "%";
             }
         },
 


### PR DESCRIPTION
Fixes #234

Using the `prettify` reverse method won't do the trick when working with `from` and `to` values.

It will require extra work to reverse inputs too, for example: Fixing to value should fix the upper bound and release the lower bound.

I approached this by reversing the UI only, which also makes it usable in a Right-to-Left layout with ease.

Not sure if this going to be merged or not! so I only reversed the HTML5 skin, other skins reversal should be straight forward! 

**TODO:**
 * Reverse the remaining skins.
 * Test all cases, I might have missed something!

Thanks




