### PR TITLE
fix a bug on onChange event not fired at first step

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -1,5 +1,5 @@
 ﻿// Ion.RangeSlider
-// version 2.1.2 Build: 350
+// version 2.1.3 Build: 350
 // © Denis Ineshin, 2015
 // https://github.com/IonDen
 //
@@ -1348,7 +1348,7 @@
                 this.old_to = this.result.to;
 
                 // callbacks call
-                if (!this.is_resize && !this.is_update && !this.is_start && !this.is_finish) {
+                if (!this.is_resize && !this.is_update && !this.is_start) {
                     this.callOnChange();
                 }
                 if (this.is_key || this.is_click) {


### PR DESCRIPTION
Hi,

I found some bug. When you slide the slider for the second time, on first step, the onChange event is not fired. So, for example you have slider from 1 to 100. Now, you can start slide it to 50, then try slide it to 51 but **_don't release the mouse**_, you'll see that onChange event is not fired. While you still hold the mouse, slide it to 52, now you'll see that onChange event is fired. That is the bug, onChange event not fired on first step.

please check this

I fix that bug with remove 

```
&& !this.is_finish
```

at line 1351
