### PR TITLE
Check undefined value

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -397,7 +397,7 @@
 
 
         // input value extends default config
-        if (val !== "") {
+        if (val !== undefined && val !== "") {
             val = val.split(config_from_data.input_values_separator || options.input_values_separator || ";");
 
             if (val[0] && val[0] == +val[0]) {


### PR DESCRIPTION
I am working with angularjs-wrapper module of ion-slider. About few weeks ago, I faced on issue 'val is undefined'. It looks like it cannot filter undefined param.

Please check and review.