### PR TITLE
fix: only require jQuery if it is not defined

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -11,11 +11,11 @@
 // =====================================================================================================================
 
 ;(function(factory) {
-    if (typeof define === "function" && define.amd) {
+    if (!jQuery && typeof define === "function" && define.amd) {
         define(["jquery"], function (jQuery) {
             return factory(jQuery, document, window, navigator);
         });
-    } else if (typeof exports === "object") {
+    } else if (!jQuery && typeof exports === "object") {
         factory(require("jquery"), document, window, navigator);
     } else {
         factory(jQuery, document, window, navigator);


### PR DESCRIPTION
When jQuery is included e.g. via a <script> tag then there is a glitch
with the required version.