### PR TITLE
Preserve decimal values even if step does not has a decimal value.

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -803,7 +803,7 @@
             if ($.contains(this.$cache.cont[0], e.target) || this.dragging) {
                 this.callOnFinish();
             }
-            
+
             this.dragging = false;
         },
 
@@ -1806,7 +1806,7 @@
                 number = number / this.options.step;
                 number = number * this.options.step;
 
-                number = +number.toFixed(0);
+                number = +number.toFixed(avg_decimals);
             }
 
             if (abs) {


### PR DESCRIPTION
## The problem:

For scenarios wherein on the passed values ( from / to ) has decimal points but the step does not has a  decimal point, the plugin **rounds off the value** . 

This might not be desirable in some cases.

## Tell me more:

Here's the [fiddle link](http://jsfiddle.net/qv6yrjrv/858/)

I would have expected the `to` value to be 45.92 but `convertToValue` rounded it to 46.

Attaching screenshot as well.

<img width="1242" alt="screen shot 2017-07-07 at 8 26 08 am" src="https://user-images.githubusercontent.com/2606564/27941712-a4fe1674-62ef-11e7-9d2f-d7be3a0f7a2a.png">

## Proposed fix.

Please refer the one liner change in this PR where we can use the `avg_decimals` computed above to preserve the required precision.

#### And we are humans with opinions and suggestions... Here's something to muse over...

There are some scenarios where such rounding do make sense.. for example the grid labels.

How about allowing a flag in the options to decide whether to round values for grid labels or not !?

P.S.: I know the guideline says 1 thing in 1 PR. But these are just some thoughts 😄 