### PR TITLE
add check for jQuery if it is not defined

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -11,11 +11,11 @@
 // =====================================================================================================================
 
 ;(function(factory) {
-    if (!jQuery && typeof define === "function" && define.amd) {
+    if ((typeof jQuery === 'undefined' || !jQuery) && typeof define === "function" && define.amd) {
         define(["jquery"], function (jQuery) {
             return factory(jQuery, document, window, navigator);
         });
-    } else if (!jQuery && typeof exports === "object") {
+    } else if ((typeof jQuery === 'undefined' || !jQuery) && typeof exports === "object") {
         factory(require("jquery"), document, window, navigator);
     } else {
         factory(jQuery, document, window, navigator);
@@ -806,7 +806,7 @@
             if ($.contains(this.$cache.cont[0], e.target) || this.dragging) {
                 this.callOnFinish();
             }
-            
+
             this.dragging = false;
         },
 


### PR DESCRIPTION
https://github.com/IonDen/ion.rangeSlider/issues/585
when jQuery is not defined, the previous check `!jQuery` is failed with reference error `jQuery is not defined`, this check will solve the problem