### PR TITLE
Various improvements to modern CSS:

### DIFF
--- a/less/skins/modern.less
+++ b/less/skins/modern.less
@@ -67,8 +67,8 @@
             position: absolute;
             display: block;
             top: -4px; left: 1px;
-            width: (@handle_width - 6px);
-            height: (@handle_width - 6px);
+            width: (@handle_width - 4px);
+            height: (@handle_width - 4px);
             border: 1px solid darken(@line_color, 15%);
             background: @handle_color_2;
             transform: rotate(45deg);
@@ -158,6 +158,7 @@
         }
 
         &-text {
+            bottom: 5px;
             color: @grid_color_2;
             font-size: 13px;
         }


### PR DESCRIPTION
Before these changes, the modern theme's handle sizing and grid text positioning looks a bit off

<img width="633" alt="Screen Shot 2020-07-02 at 9 49 31 AM" src="https://user-images.githubusercontent.com/1365941/86375275-117a0580-bc4b-11ea-885d-5ae025f74a98.png">

After these changes, it looks slightly better by default

<img width="630" alt="Screen Shot 2020-07-02 at 9 53 00 AM" src="https://user-images.githubusercontent.com/1365941/86375298-1939aa00-bc4b-11ea-8d10-cece50d37080.png">
