### PR TITLE
Point bower.json main at the files that exist

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,9 +16,7 @@
     },
     "main": [
         "js/ion.rangeSlider.js",
-        "css/ion.rangeSlider.css",
-        "css/ion.rangeSlider.skinFlat.css",
-        "img/sprite-skin-flat.png"
+        "css/ion.rangeSlider.css"
     ],
     "dependencies": {
         "jquery": ">=1.8"


### PR DESCRIPTION
Refs #798 (closes with the release that carries it). The two assets removed in 2.3.0 are dropped from main; the JS and the single CSS file remain.