### PR TITLE
Remove an IE8 syntax error and guard console

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 2. Function and method names should be written in camelCase
 3. Variables name should be written in lower_case
 4. New methods should have JSDoc descriptions
+5. `js/ion.rangeSlider.js` must stay ECMAScript 3 so IE8 can parse it: no trailing commas in object or array literals, no ES5+ syntax, no ES5 built-ins (`forEach`, `Object.keys`, `trim`…) without the polyfills already in the file, and guard `console`. The build rejects ES5+ syntax and object-literal trailing commas; array trailing commas, reserved words after a dot (`o.class`) and ES5 built-ins are not caught automatically, so watch for them in review.
 
 ### Guide for Pull Requests with bug fixes
 

--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -337,7 +337,9 @@
 
         // check if base element is input
         if ($inp[0].nodeName !== "INPUT") {
-            console && console.warn && console.warn("Base element should be <input>!", $inp[0]);
+            if (typeof console !== "undefined" && console.warn) {
+                console.warn("Base element should be <input>!", $inp[0]);
+            }
         }
 
 
@@ -394,7 +396,7 @@
             disable: $inp.data("disable"),
             block: $inp.data("block"),
 
-            extra_classes: $inp.data("extraClasses"),
+            extra_classes: $inp.data("extraClasses")
         };
         config_from_data.values = config_from_data.values && config_from_data.values.split(",");
 


### PR DESCRIPTION
Refs #797 (closes with the release). Verified with acorn in ES3 mode; no behaviour change. This must merge before the build-system PR, whose ES3 gate fails on the old line 397.