### PR TITLE
Add a reproducible build script for the shipped files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+js/ion.rangeSlider.min.js -diff
+css/ion.rangeSlider.min.css -diff

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea
+node_modules/
+test-results/
+playwright-report/

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-.idea
-.github
-_tmp
-PSD
-bower.json
-.npmignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,7 @@
 ### Where the work is tracked
 
 Open issues and PRs that fit the 2.x line are on the project board: https://github.com/users/IonDen/projects/1. Issues stay open until the fix is in a tagged release. Usage questions belong in Discussions → Q&A.
+
+### Building and testing
+
+Node 22 or newer is needed to build and test (consumers need nothing: `js/` and `css/` are committed). `npm install`, then `npm run build` regenerates the four shipped files from `less/` and `js/ion.rangeSlider.js`; `npm test` runs the unit tests. A pull request that touches `js/` or `less/` must include the rebuilt files (CI checks that they match). Resolve conflicts in the minified files by rebuilding, never by hand.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 2. Function and method names should be written in camelCase
 3. Variables name should be written in lower_case
 4. New methods should have JSDoc descriptions
-5. `js/ion.rangeSlider.js` must stay ECMAScript 3 so IE8 can parse it: no trailing commas in object or array literals, no ES5+ syntax, no ES5 built-ins (`forEach`, `Object.keys`, `trim`…) without the polyfills already in the file, and guard `console`. The build rejects ES5+ syntax and object-literal trailing commas; array trailing commas, reserved words after a dot (`o.class`) and ES5 built-ins are not caught automatically, so watch for them in review.
+5. `js/ion.rangeSlider.js` must stay ECMAScript 3 so IE8 can parse it: no trailing commas in object or array literals, no ES5+ syntax, no ES5 built-ins (`forEach`, `Object.keys`, `trim`…) without the polyfills already in the file, and guard `console`. The build rejects ES5+ syntax, object-literal trailing commas, and ES3 reserved words used as identifiers, object keys or after a dot; array trailing commas and ES5 built-ins are not caught automatically, so watch for them in review.
 
 ### Guide for Pull Requests with bug fixes
 
@@ -33,4 +33,4 @@ Open issues and PRs that fit the 2.x line are on the project board: https://gith
 
 ### Building and testing
 
-Node 22 or newer is needed to build and test (consumers need nothing: `js/` and `css/` are committed). `npm install`, then `npm run build` regenerates the four shipped files from `less/` and `js/ion.rangeSlider.js`; `npm test` runs the unit tests. A pull request that touches `js/` or `less/` must include the rebuilt files (CI checks that they match). Resolve conflicts in the minified files by rebuilding, never by hand.
+Node 22 or newer is needed to build and test (consumers need nothing: `js/` and `css/` are committed). `npm install`, then `npm run build` regenerates the three built files (`css/ion.rangeSlider.css` and the two minified files) from `less/` and `js/ion.rangeSlider.js`; `npm test` runs the unit tests. A pull request that touches `js/` or `less/` must include the rebuilt files (CI checks that the committed files match). Resolve conflicts in the minified files by rebuilding, never by hand.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,365 @@
+{
+    "name": "ion-rangeslider",
+    "version": "2.3.1",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "ion-rangeslider",
+            "version": "2.3.1",
+            "license": "MIT",
+            "devDependencies": {
+                "acorn": "^8.15.0",
+                "clean-css": "5.3.3",
+                "less": "4.9.0",
+                "uglify-js": "3.19.3"
+            },
+            "peerDependencies": {
+                "jquery": ">=1.8"
+            }
+        },
+        "node_modules/acorn": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/clean-css": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+            "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "source-map": "~0.6.0"
+            },
+            "engines": {
+                "node": ">= 10.0"
+            }
+        },
+        "node_modules/copy-anything": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+            "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-what": "^4.1.8"
+            },
+            "engines": {
+                "node": ">=12.13"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
+            }
+        },
+        "node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/errno": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+            "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "prr": "~1.0.1"
+            },
+            "bin": {
+                "errno": "cli.js"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC",
+            "optional": true
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-what": {
+            "version": "4.1.16",
+            "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+            "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.13"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
+            }
+        },
+        "node_modules/jquery": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
+            "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/less": {
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/less/-/less-4.9.0.tgz",
+            "integrity": "sha512-umRhrCH7fCi8Uj2RcwKjJdvUORTjeWqkdKx0LbcZvjIwsAVsnIAGcxHaqowPeBFBjQuWOeC/bve0AlpFzF/+SQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "copy-anything": "^3.0.5",
+                "parse-node-version": "^1.0.1"
+            },
+            "bin": {
+                "lessc": "bin/lessc"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "errno": "^0.1.1",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^5.1.0",
+                "mime": "^1.4.1",
+                "needle": "^3.1.0",
+                "probe-image-size": "^7.2.3",
+                "source-map": "~0.6.0"
+            }
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/make-dir": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-5.1.0.tgz",
+            "integrity": "sha512-IfpFq6UM39dUNiphpA6uDezNx/AvWyhwfICWPR3t1VspkgkMZrL+Rk1RbN1bx+aeNYwOrqGJgEgV3yotk+ZUVw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/needle": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+            "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "iconv-lite": "^0.6.3",
+                "sax": "^1.2.4"
+            },
+            "bin": {
+                "needle": "bin/needle"
+            },
+            "engines": {
+                "node": ">= 4.4.x"
+            }
+        },
+        "node_modules/parse-node-version": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+            "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/probe-image-size": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.4.0.tgz",
+            "integrity": "sha512-cdEprVtZxV+awMde9X+4jILBFYh4CARxVrQaMl4wY4YcPWbul9jntXrIW95NInBDyJwcVUP3U0T6yukN8rMBaQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "lodash.merge": "^4.6.2",
+                "needle": "^2.5.2",
+                "stream-parser": "~0.3.1"
+            }
+        },
+        "node_modules/probe-image-size/node_modules/debug": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ms": "^2.1.1"
+            }
+        },
+        "node_modules/probe-image-size/node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/probe-image-size/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/probe-image-size/node_modules/needle": {
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+            "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "debug": "^3.2.6",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+            },
+            "bin": {
+                "needle": "bin/needle"
+            },
+            "engines": {
+                "node": ">= 4.4.x"
+            }
+        },
+        "node_modules/prr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/sax": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+            "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "optional": true,
+            "engines": {
+                "node": ">=11.0.0"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/stream-parser": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+            "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "debug": "2"
+            }
+        },
+        "node_modules/uglify-js": {
+            "version": "3.19.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
         "skins"
     ],
     "main": "./js/ion.rangeSlider.js",
-    "directories": {
-        "lib": "js"
-    },
+    "files": ["js/", "css/", "less/", "readme.md", "history.md", "License.md"],
     "repository": {
         "type": "git",
         "url": "git://github.com/IonDen/ion.rangeSlider.git"
@@ -38,10 +36,19 @@
     "peerDependencies": {
         "jquery": ">=1.8"
     },
-    "ignore": [
-        ".idea",
-        "_tmp",
-        "PSD",
-        "bower.json"
-    ]
+    "config": {
+        "build": 382,
+        "buildDate": "2019-12-19 16:51:02"
+    },
+    "scripts": {
+        "build": "node scripts/build.mjs",
+        "test": "npm run test:build",
+        "test:build": "node --test test/build/*.test.mjs"
+    },
+    "devDependencies": {
+        "acorn": "^8.15.0",
+        "clean-css": "5.3.3",
+        "less": "4.9.0",
+        "uglify-js": "3.19.3"
+    }
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -47,4 +47,5 @@ if (out.errors.length) throw new Error(out.errors.join('\n'));
 writeFileSync(at('css/ion.rangeSlider.min.css'), b.cssMin + out.styles);
 
 console.log(`built ${pkg.version} (build ${pkg.config.build}, ${pkg.config.buildDate}): ` +
-  `min.js ${min.code.length} B, css ${css.length} B, min.css ${out.styles.length} B`);
+  `min.js ${Buffer.byteLength(min.code, 'utf8')} B, css ${Buffer.byteLength(css, 'utf8')} B, ` +
+  `min.css ${Buffer.byteLength(out.styles, 'utf8')} B`);

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Builds the four distributed files from the sources. Deterministic: every stamp
+// (version, build counter, build date) comes from package.json, so `npm run build`
+// on a clean checkout reproduces the committed files byte for byte.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import less from 'less';
+import CleanCSS from 'clean-css';
+import { minify } from 'uglify-js';
+import { banners } from './lib/banners.mjs';
+import { assertEs3 } from './lib/es3.mjs';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const at = (p) => resolve(root, p);
+const pkg = JSON.parse(readFileSync(at('package.json'), 'utf8'));
+const b = banners(pkg);
+
+// 1. The unminified JS is the source itself; refuse to build if its header drifted from package.json.
+const source = readFileSync(at('js/ion.rangeSlider.js'), 'utf8');
+const lines = source.split('\n');
+if (lines[1] !== b.sourceHeader || lines[2] !== b.sourceCopyright) {
+  throw new Error(`js/ion.rangeSlider.js header is\n${lines[1]}\n${lines[2]}\nbut package.json implies\n${b.sourceHeader}\n${b.sourceCopyright}\nRun npm run release to bump, or fix package.json.`);
+}
+if (!source.includes(`this.VERSION = "${pkg.version}";`)) {
+  throw new Error(`this.VERSION in js/ion.rangeSlider.js does not match package.json version ${pkg.version}`);
+}
+assertEs3(source, 'js/ion.rangeSlider.js');
+
+// 2. Minified JS, ES3-safe for IE8.
+const min = minify(source, { ie: true, output: { preamble: b.js } });
+if (min.error) throw min.error;
+if (min.code.split('\n')[0] !== b.js || min.code.length < 20000) {
+  throw new Error('minified output is missing its banner line or is suspiciously small');
+}
+assertEs3(min.code, 'js/ion.rangeSlider.min.js');
+writeFileSync(at('js/ion.rangeSlider.min.js'), min.code);
+
+// 3. CSS from LESS (the plain render matches the committed file), then the banner.
+const lessSrc = readFileSync(at('less/irs.less'), 'utf8');
+const { css } = await less.render(lessSrc, { filename: at('less/irs.less') });
+writeFileSync(at('css/ion.rangeSlider.css'), b.css + css);
+
+// 4. Minified CSS with the one-line banner and no trailing newline.
+const out = new CleanCSS({ level: 1 }).minify(css);
+if (out.errors.length) throw new Error(out.errors.join('\n'));
+writeFileSync(at('css/ion.rangeSlider.min.css'), b.cssMin + out.styles);
+
+console.log(`built ${pkg.version} (build ${pkg.config.build}, ${pkg.config.buildDate}): ` +
+  `min.js ${min.code.length} B, css ${css.length} B, min.css ${out.styles.length} B`);

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,26 +1,28 @@
 #!/usr/bin/env node
-// Builds the four distributed files from the sources. Deterministic: every stamp
+// Builds the three built files from the sources. Deterministic: every stamp
 // (version, build counter, build date) comes from package.json, so `npm run build`
 // on a clean checkout reproduces the committed files byte for byte.
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import less from 'less';
-import CleanCSS from 'clean-css';
 import { minify } from 'uglify-js';
 import { banners } from './lib/banners.mjs';
 import { assertEs3 } from './lib/es3.mjs';
+import { compileCss } from './lib/css.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const at = (p) => resolve(root, p);
 const pkg = JSON.parse(readFileSync(at('package.json'), 'utf8'));
+if (!pkg.config || typeof pkg.config.build !== 'number' || !pkg.config.buildDate) {
+  throw new Error('package.json is missing "config" with build and buildDate');
+}
 const b = banners(pkg);
 
 // 1. The unminified JS is the source itself; refuse to build if its header drifted from package.json.
 const source = readFileSync(at('js/ion.rangeSlider.js'), 'utf8');
 const lines = source.split('\n');
 if (lines[1] !== b.sourceHeader || lines[2] !== b.sourceCopyright) {
-  throw new Error(`js/ion.rangeSlider.js header is\n${lines[1]}\n${lines[2]}\nbut package.json implies\n${b.sourceHeader}\n${b.sourceCopyright}\nRun npm run release to bump, or fix package.json.`);
+  throw new Error(`js/ion.rangeSlider.js header is\n${lines[1]}\n${lines[2]}\nbut package.json implies\n${b.sourceHeader}\n${b.sourceCopyright}\nUpdate package.json (version / config.build / config.buildDate) or the header lines so they agree.`);
 }
 if (!source.includes(`this.VERSION = "${pkg.version}";`)) {
   throw new Error(`this.VERSION in js/ion.rangeSlider.js does not match package.json version ${pkg.version}`);
@@ -36,16 +38,15 @@ if (min.code.split('\n')[0] !== b.js || min.code.length < 20000) {
 assertEs3(min.code, 'js/ion.rangeSlider.min.js');
 writeFileSync(at('js/ion.rangeSlider.min.js'), min.code);
 
-// 3. CSS from LESS (the plain render matches the committed file), then the banner.
+// 3. CSS from LESS (the plain render matches the committed file) and minified CSS,
+// in IE8 compatibility mode so the `.lt-ie9` filter fallback survives; banners added here.
 const lessSrc = readFileSync(at('less/irs.less'), 'utf8');
-const { css } = await less.render(lessSrc, { filename: at('less/irs.less') });
-writeFileSync(at('css/ion.rangeSlider.css'), b.css + css);
-
-// 4. Minified CSS with the one-line banner and no trailing newline.
-const out = new CleanCSS({ level: 1 }).minify(css);
-if (out.errors.length) throw new Error(out.errors.join('\n'));
-writeFileSync(at('css/ion.rangeSlider.min.css'), b.cssMin + out.styles);
+const { css, min: cssMin } = await compileCss(lessSrc, at('less/irs.less'));
+const cssOut = b.css + css;
+const cssMinOut = b.cssMin + cssMin;
+writeFileSync(at('css/ion.rangeSlider.css'), cssOut);
+writeFileSync(at('css/ion.rangeSlider.min.css'), cssMinOut);
 
 console.log(`built ${pkg.version} (build ${pkg.config.build}, ${pkg.config.buildDate}): ` +
-  `min.js ${Buffer.byteLength(min.code, 'utf8')} B, css ${Buffer.byteLength(css, 'utf8')} B, ` +
-  `min.css ${Buffer.byteLength(out.styles, 'utf8')} B`);
+  `min.js ${Buffer.byteLength(min.code, 'utf8')} B, css ${Buffer.byteLength(cssOut, 'utf8')} B, ` +
+  `min.css ${Buffer.byteLength(cssMinOut, 'utf8')} B`);

--- a/scripts/lib/banners.mjs
+++ b/scripts/lib/banners.mjs
@@ -1,0 +1,15 @@
+/** Banner strings for the shipped files, stamped only from package.json. */
+export function banners(pkg) {
+  const version = pkg.version;
+  const build = pkg.config.build;
+  const date = pkg.config.buildDate;
+  const year = date.slice(0, 4);
+  const owner = `© Denis Ineshin, 2010 - ${year}, IonDen.com`;
+  return {
+    sourceHeader: `// version ${version} Build: ${build}`,
+    sourceCopyright: `// © Denis Ineshin, ${year}`,
+    js: `// Ion.RangeSlider, ${version}, ${owner}, Build date: ${date}`,
+    css: `/**\nIon.RangeSlider, ${version}\n${owner}\nBuild date: ${date}\n*/\n`,
+    cssMin: `/*!Ion.RangeSlider, ${version}, ${owner}, Build date: ${date}*/`,
+  };
+}

--- a/scripts/lib/css.mjs
+++ b/scripts/lib/css.mjs
@@ -1,0 +1,21 @@
+import less from 'less';
+import CleanCSS from 'clean-css';
+
+/**
+ * Compiles LESS to plain CSS and to minified CSS, in IE8+ compatibility mode.
+ * clean-css's default (IE10+) compatibility strips `filter`/`-ms-filter`
+ * declarations as dead weight, but `.lt-ie9 .irs-disable-mask` relies on
+ * `filter:alpha(opacity=0)` for IE8/9, which this project still supports.
+ * Throws on any less or clean-css error or warning; no option here is meant
+ * to silence one.
+ */
+export async function compileCss(lessSrc, filename) {
+  const rendered = await less.render(lessSrc, { filename: filename });
+  const css = rendered.css;
+
+  const out = new CleanCSS({ level: 1, compatibility: 'ie8' }).minify(css);
+  const problems = (out.errors || []).concat(out.warnings || []);
+  if (problems.length) throw new Error(problems.join('\n'));
+
+  return { css: css, min: out.styles };
+}

--- a/scripts/lib/es3.mjs
+++ b/scripts/lib/es3.mjs
@@ -2,14 +2,14 @@ import * as acorn from 'acorn';
 
 /**
  * Throws unless `code` parses as ECMAScript 3 (what IE8 runs). Catches ES5+ syntax,
- * object-literal trailing commas and ES3 reserved words used as identifiers.
- * Not caught (acorn accepts them): array-literal trailing commas, reserved words
- * after a dot (`o.class`; uglify-js in ie mode quotes those in the minified file),
- * and ES5 built-ins such as forEach/Object.keys. Review still has to watch for those.
+ * object-literal trailing commas, and ES3 reserved words used as identifiers,
+ * object keys, or after a dot (`allowReserved: 'never'` is acorn's IE-parser mode).
+ * Not caught (acorn accepts them): array-literal trailing commas and ES5 built-ins
+ * such as forEach/Object.keys. Review still has to watch for those.
  */
 export function assertEs3(code, label) {
   try {
-    acorn.parse(code, { ecmaVersion: 3, allowReserved: false, sourceType: 'script' });
+    acorn.parse(code, { ecmaVersion: 3, allowReserved: 'never', sourceType: 'script' });
   } catch (e) {
     throw new Error(`${label} is not ES3-safe: ${e.message}`);
   }

--- a/scripts/lib/es3.mjs
+++ b/scripts/lib/es3.mjs
@@ -1,0 +1,16 @@
+import * as acorn from 'acorn';
+
+/**
+ * Throws unless `code` parses as ECMAScript 3 (what IE8 runs). Catches ES5+ syntax,
+ * object-literal trailing commas and ES3 reserved words used as identifiers.
+ * Not caught (acorn accepts them): array-literal trailing commas, reserved words
+ * after a dot (`o.class`; uglify-js in ie mode quotes those in the minified file),
+ * and ES5 built-ins such as forEach/Object.keys. Review still has to watch for those.
+ */
+export function assertEs3(code, label) {
+  try {
+    acorn.parse(code, { ecmaVersion: 3, allowReserved: false, sourceType: 'script' });
+  } catch (e) {
+    throw new Error(`${label} is not ES3-safe: ${e.message}`);
+  }
+}

--- a/test/build/banners.test.mjs
+++ b/test/build/banners.test.mjs
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { banners } from '../../scripts/lib/banners.mjs';
+
+const pkg = { version: '2.3.1', config: { build: 382, buildDate: '2019-12-19 16:51:02' } };
+
+test('banners reproduce the 2.3.1 formats byte for byte', () => {
+  const b = banners(pkg);
+  assert.equal(b.css, '/**\nIon.RangeSlider, 2.3.1\n© Denis Ineshin, 2010 - 2019, IonDen.com\nBuild date: 2019-12-19 16:51:02\n*/\n');
+  assert.equal(b.cssMin, '/*!Ion.RangeSlider, 2.3.1, © Denis Ineshin, 2010 - 2019, IonDen.com, Build date: 2019-12-19 16:51:02*/');
+  assert.equal(b.js, '// Ion.RangeSlider, 2.3.1, © Denis Ineshin, 2010 - 2019, IonDen.com, Build date: 2019-12-19 16:51:02');
+  assert.equal(b.sourceHeader, '// version 2.3.1 Build: 382');
+  assert.equal(b.sourceCopyright, '// © Denis Ineshin, 2019');
+});
+
+test('year follows the build date', () => {
+  const b = banners({ version: '2.4.0', config: { build: 400, buildDate: '2027-01-05 10:00:00' } });
+  assert.match(b.js, / 2010 - 2027, /);
+  assert.equal(b.sourceCopyright, '// © Denis Ineshin, 2027');
+});

--- a/test/build/css.test.mjs
+++ b/test/build/css.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { compileCss } from '../../scripts/lib/css.mjs';
+
+const lessUrl = new URL('../../less/irs.less', import.meta.url);
+const cssUrl = new URL('../../css/ion.rangeSlider.css', import.meta.url);
+
+test('compiling less/irs.less keeps the IE8 filter fallback and matches the committed CSS', async () => {
+  const lessSrc = readFileSync(lessUrl, 'utf8');
+  const { css, min } = await compileCss(lessSrc, lessUrl.pathname);
+
+  // (a) the IE8/9 opacity fallback survives minification (default clean-css
+  // compatibility strips it, since it targets IE10+, which never needs it).
+  assert.match(min, /filter:alpha\(opacity=0\)/);
+  // (b) ...and is present in the unminified render too.
+  assert.match(css, /filter: alpha\(opacity=0\);/);
+  // (c) the minified output is a single line with no banner (the build adds it).
+  assert.equal(min.indexOf('\n'), -1);
+  assert.equal(min.startsWith('/*'), false);
+  // (d) the plain render reproduces the committed file, byte for byte, once its
+  // 5-line banner comment is stripped.
+  const committed = readFileSync(cssUrl, 'utf8');
+  const committedBody = committed.split('\n').slice(5).join('\n');
+  assert.equal(css, committedBody);
+});

--- a/test/build/es3.test.mjs
+++ b/test/build/es3.test.mjs
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { assertEs3 } from '../../scripts/lib/es3.mjs';
+
+test('rejects ES5+ syntax, object trailing commas and ES3 reserved words', () => {
+  assert.throws(() => assertEs3('var a = {b: 1,};', 'x'), /not ES3-safe/);
+  assert.throws(() => assertEs3('var f = () => 1;', 'x'), /not ES3-safe/);
+  assert.throws(() => assertEs3('var int = 1;', 'x'), /not ES3-safe/);   // reserved in ES3 only: exercises allowReserved
+  assert.doesNotThrow(() => assertEs3('var a = {b: 1}; function f() { return a; }', 'x'));
+});
+
+test('the shipped source is ES3-safe', () => {
+  assertEs3(readFileSync(new URL('../../js/ion.rangeSlider.js', import.meta.url), 'utf8'), 'js/ion.rangeSlider.js');
+});

--- a/test/build/es3.test.mjs
+++ b/test/build/es3.test.mjs
@@ -1,15 +1,25 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { minify } from 'uglify-js';
 import { assertEs3 } from '../../scripts/lib/es3.mjs';
 
 test('rejects ES5+ syntax, object trailing commas and ES3 reserved words', () => {
   assert.throws(() => assertEs3('var a = {b: 1,};', 'x'), /not ES3-safe/);
   assert.throws(() => assertEs3('var f = () => 1;', 'x'), /not ES3-safe/);
   assert.throws(() => assertEs3('var int = 1;', 'x'), /not ES3-safe/);   // reserved in ES3 only: exercises allowReserved
+  assert.throws(() => assertEs3('var o = {}; o.class = 1;', 'x'), /not ES3-safe/);   // reserved word after a dot
+  assert.throws(() => assertEs3('var o = {class: 1};', 'x'), /not ES3-safe/);   // reserved word as an object key
   assert.doesNotThrow(() => assertEs3('var a = {b: 1}; function f() { return a; }', 'x'));
 });
 
 test('the shipped source is ES3-safe', () => {
   assertEs3(readFileSync(new URL('../../js/ion.rangeSlider.js', import.meta.url), 'utf8'), 'js/ion.rangeSlider.js');
+});
+
+test('uglify-js in ie mode keeps the minified output ES3-safe', () => {
+  const source = readFileSync(new URL('../../js/ion.rangeSlider.js', import.meta.url), 'utf8');
+  const min = minify(source, { ie: true });
+  if (min.error) throw min.error;
+  assertEs3(min.code, 'js/ion.rangeSlider.min.js');
 });


### PR DESCRIPTION
## What this does

Adds `npm run build`: a small Node script (`scripts/build.mjs`, plus `scripts/lib/banners.mjs`, `scripts/lib/es3.mjs` and `scripts/lib/css.mjs`) that compiles `less/irs.less` to `css/ion.rangeSlider.css`, minifies both CSS (clean-css, `ie8` compatibility) and JS (uglify-js, `ie: true` mode) and stamps all four shipped-file banners from `package.json`'s `version`/`config.build`/`config.buildDate`. The build refuses to run if the source's `js/ion.rangeSlider.js` header/`this.VERSION` drift from `package.json`, or if the source or minified JS output is not ES3-safe (checked with `acorn`, `ecmaVersion: 3`, `allowReserved: 'never'`). Locally it reproduces `css/ion.rangeSlider.css` byte for byte and regenerates both minified files with different bodies from the committed ones (today's `uglify-js`/`clean-css` versions vs. the 2019 toolchain) — see "Local build output" below. **This PR ships the build script only; none of that regenerated output is committed here.**

`npm run test:build` (`npm test`) runs 6 `node --test` unit tests: the banner-string formats against the known 2.3.1 values, the LESS/clean-css pipeline (including that it keeps the IE8 opacity fallback — see the CSS section below), and the ES3 checker, including that both the shipped source and its `uglify-js --ie` minified output still parse as ES3.

The tarball whitelist moves from `.npmignore` (blacklist) to `package.json`'s `files` field (explicit whitelist).

### CSS pipeline: `filter:alpha(opacity=0)` (blocker, fixed)

clean-css's default compatibility mode (IE10+) strips `filter`/`-ms-filter` declarations as dead weight — which deleted `filter:alpha(opacity=0)` from `.lt-ie9 .irs-disable-mask` in the freshly-built `min.css`, even though it's in the 2019 committed file. Fixed by pinning `compatibility: 'ie8'` in the new `scripts/lib/css.mjs` (its `DEFAULTS.ie8` turns `properties.ieFilters` back on). `test/build/css.test.mjs` now compiles the real `less/irs.less` and pins this as a regression: the minified output must contain `filter:alpha(opacity=0)`, and the plain render must equal the committed `css/ion.rangeSlider.css` (minus its banner) byte for byte.

I also checked whether the filter was the *only* difference between the freshly-built `min.css` and the 2019 committed one. It isn't: with the `ie8` fix, the `.lt-ie9 .irs-disable-mask` rule itself is now byte-identical to 2019, but 41 of the file's 107 minified rule blocks still differ for unrelated reasons — all clean-css-version-driven formatting, not behavior changes: multi-selector lists get alphabetized (`.irs-min,.irs-max` → `.irs-max,.irs-min`), `white` shortens to `#fff`, `none`/`0%` shorten to `0`, leading zeros drop from decimals (`0.5` → `.5`), and spacing around `!important`/commas tightens. None of this is shipped in this PR.

### ES3 gate strengthened

`assertEs3` now uses `allowReserved: 'never'` (acorn's IE-parser mode) instead of `allowReserved: false`, which additionally rejects ES3 reserved words used as object keys (`{class: 1}`) or after a dot (`o.class`), not just as bare identifiers — closing the gap the original docstring called out as unchecked. Both the shipped source and `uglify-js`'s `ie: true` minified output still pass; a new test locks the latter in as a regression guard, since it's uglify's IE-mode reserved-word quoting that's supposed to keep it safe.

### No shipped file changes

`js/ion.rangeSlider.js`, `css/ion.rangeSlider.css`, `js/ion.rangeSlider.min.js` and `css/ion.rangeSlider.min.css` are byte-identical to `master`. I ran `npm run build` locally, inspected the diff, ran it a second time to confirm determinism (no further diff), then reverted the output with `git checkout -- js css`. The regenerated minified files will be committed for real in a follow-up PR once the browser test suite can exercise them.

### Local build output (reverted, not committed)

```
$ npm run build
built 2.3.1 (build 382, 2019-12-19 16:51:02): min.js 40970 B, css 13296 B, min.css 10981 B
```

`git diff --stat -- js css` after the build:
```
 css/ion.rangeSlider.min.css | Bin 11084 -> 10981 bytes
 js/ion.rangeSlider.min.js   | Bin 41171 -> 40970 bytes
 2 files changed, 0 insertions(+), 0 deletions(-)
```
(`css/ion.rangeSlider.css` shows no diff at all — the LESS render reproduces it exactly.) One visible change in both minified banners is the timestamp: the old `min.js` banner reads `Build date: 2019-12-19 16:56:44` (a few minutes after the CSS banner's `16:51:02`, since the 2019 toolchain stamped each file separately); the rebuild uses one `buildDate` for everything, so both now read `16:51:02`. Beyond the banner, the minified bodies also differ (see the byte counts and the CSS section above); the JS minifier-version delta wasn't inspected block by block since none of it ships here.

### Tarball, before (`.npmignore` blacklist) vs after (`files` whitelist)

Before:
```
.editorconfig
CONTRIBUTING.md
License.md
css/ion.rangeSlider.css
css/ion.rangeSlider.min.css
history.md
js/ion.rangeSlider.js
js/ion.rangeSlider.min.js
less/_base.less
less/_mixins.less
less/irs.less
less/skins/big.less
less/skins/flat.less
less/skins/modern.less
less/skins/round.less
less/skins/sharp.less
less/skins/square.less
package.json
readme.md
```

After:
```
License.md
css/ion.rangeSlider.css
css/ion.rangeSlider.min.css
history.md
js/ion.rangeSlider.js
js/ion.rangeSlider.min.js
less/_base.less
less/_mixins.less
less/irs.less
less/skins/big.less
less/skins/flat.less
less/skins/modern.less
less/skins/round.less
less/skins/sharp.less
less/skins/square.less
package.json
readme.md
```

Only `.editorconfig` and `CONTRIBUTING.md` drop out of the published npm package; everything consumers need (`js/`, `css/`, `less/`, `readme.md`, `history.md`, `License.md`) is unchanged. (`scripts/`, `test/` and the dev config files were never part of any published tarball and stay out either way.)

### devDependencies pinned exactly (output is a committed artifact)

- `less` 4.9.0
- `clean-css` 5.3.3
- `uglify-js` 3.19.3
- `acorn` `^8.15.0` — a build dependency, not test-only: `scripts/lib/es3.mjs` uses it inside `scripts/build.mjs` itself to gate both the source and the minified output, in addition to the unit tests. It's not pinned exactly because it produces no shipped artifact, only a pass/fail check.

Refs #802

