### PR TITLE
Add unit tests for the conversion, validation and prettify logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,142 @@
             "devDependencies": {
                 "acorn": "^8.15.0",
                 "clean-css": "5.3.3",
+                "jquery": "3.7.1",
+                "jsdom": "^26.1.0",
                 "less": "4.9.0",
                 "uglify-js": "3.19.3"
             },
             "peerDependencies": {
                 "jquery": ">=1.8"
+            }
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/css-calc": "^2.1.3",
+                "@csstools/css-color-parser": "^3.0.9",
+                "@csstools/css-parser-algorithms": "^3.0.4",
+                "@csstools/css-tokenizer": "^3.0.3",
+                "lru-cache": "^10.4.3"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+            "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^5.1.0",
+                "@csstools/css-calc": "^2.1.4"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/acorn": {
@@ -29,6 +160,16 @@
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/clean-css": {
@@ -60,6 +201,34 @@
                 "url": "https://github.com/sponsors/mesqueeb"
             }
         },
+        "node_modules/cssstyle": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+            "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^3.2.0",
+                "rrweb-cssom": "^0.8.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/data-urls": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -69,6 +238,26 @@
             "optional": true,
             "dependencies": {
                 "ms": "2.0.0"
+            }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/errno": {
@@ -93,19 +282,116 @@
             "license": "ISC",
             "optional": true
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-encoding": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/http-proxy-agent/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/http-proxy-agent/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/https-proxy-agent/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/https-proxy-agent/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-what": {
             "version": "4.1.16",
@@ -121,11 +407,51 @@
             }
         },
         "node_modules/jquery": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
-            "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jsdom": {
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+            "dev": true,
             "license": "MIT",
-            "peer": true
+            "dependencies": {
+                "cssstyle": "^4.2.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.5.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "nwsapi": "^2.2.16",
+                "parse5": "^7.2.1",
+                "rrweb-cssom": "^0.8.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^5.1.1",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.1.1",
+                "ws": "^8.18.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/less": {
             "version": "4.9.0",
@@ -160,6 +486,13 @@
             "dev": true,
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/make-dir": {
             "version": "5.1.0",
@@ -215,6 +548,13 @@
                 "node": ">= 4.4.x"
             }
         },
+        "node_modules/nwsapi": {
+            "version": "2.2.24",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+            "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/parse-node-version": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
@@ -223,6 +563,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "node_modules/probe-image-size": {
@@ -308,13 +661,29 @@
             "license": "MIT",
             "optional": true
         },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/rrweb-cssom": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+            "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true,
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/sax": {
             "version": "1.6.1",
@@ -325,6 +694,19 @@
             "optional": true,
             "engines": {
                 "node": ">=11.0.0"
+            }
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
             }
         },
         "node_modules/source-map": {
@@ -348,6 +730,59 @@
                 "debug": "2"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tldts": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+            "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^6.1.86"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tough-cookie": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^6.1.32"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/uglify-js": {
             "version": "3.19.3",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -360,6 +795,106 @@
             "engines": {
                 "node": ">=0.8.0"
             }
+        },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+            "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -42,12 +42,15 @@
     },
     "scripts": {
         "build": "node scripts/build.mjs",
-        "test": "npm run test:build",
-        "test:build": "node --test test/build/*.test.mjs"
+        "test": "npm run test:build && npm run test:unit",
+        "test:build": "node --test test/build/*.test.mjs",
+        "test:unit": "node --test test/unit/*.test.mjs"
     },
     "devDependencies": {
         "acorn": "^8.15.0",
         "clean-css": "5.3.3",
+        "jquery": "3.7.1",
+        "jsdom": "^26.1.0",
         "less": "4.9.0",
         "uglify-js": "3.19.3"
     }

--- a/test/unit/config-precedence.test.mjs
+++ b/test/unit/config-precedence.test.mjs
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSlider, plain } from './helpers.mjs';
+
+test('input value sets from/to, JS options override it, data-* override JS options', (t) => {
+  const { slider } = createSlider(t, '<input value="25;42" data-max="500">', { type: 'double', min: 0, max: 100, to: 60 });
+  assert.equal(slider.options.from, 25);    // from the value attribute
+  assert.equal(slider.options.to, 60);      // JS option beats the value attribute
+  assert.equal(slider.options.max, 500);    // data-max beats the JS option
+});
+
+test('data-values is split on commas; an input value is looked up in the JS values array', (t) => {
+  const { slider } = createSlider(t, '<input value="b" data-values="a,b,c">', { values: ['x'] });
+  assert.deepEqual(plain(slider.options.values), ['a', 'b', 'c']);
+  assert.equal(slider.options.from, 0);     // 'b' is not in ['x'] → index -1 → clamped to min
+});
+
+test('the input is written on init and the instance handle is stored', (t) => {
+  const { slider, $input, $ } = createSlider(t, '<input>', { min: 0, max: 10, from: 3 });
+  assert.equal($input.val(), '3');
+  assert.equal($input.data('from'), 3);
+  assert.equal($.data($input[0], 'ionRangeSlider'), slider);
+});

--- a/test/unit/conversions.test.mjs
+++ b/test/unit/conversions.test.mjs
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSlider } from './helpers.mjs';
+
+test('jsdom has no layout (canary for anyone adding geometry tests here)', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: 0, max: 100 });
+  assert.equal(slider.coords.w_rs, 0);
+});
+
+test('convertToPercent / convertToValue round-trip with a positive range', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: 0, max: 200, step: 1 });
+  assert.equal(slider.convertToPercent(50), 25);
+  assert.equal(slider.convertToValue(25), 50);
+  assert.equal(slider.convertToValue(0), 0);
+  assert.equal(slider.convertToValue(100), 200);
+});
+
+test('negative min and fractional step keep the decimals of the step', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: -1, max: 1, step: 0.1 });
+  assert.equal(slider.convertToPercent(0), 50);
+  assert.equal(slider.convertToValue(50), 0);
+  assert.equal(slider.convertToValue(75), 0.5);
+});
+
+test('calcWithStep snaps a percent to the step grid and clamps at 100', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: 0, max: 10, step: 2 }); // p_step = 20
+  assert.equal(slider.calcWithStep(29), 20);
+  assert.equal(slider.calcWithStep(31), 40);
+  assert.equal(slider.calcWithStep(100), 100);
+});
+
+test('checkDiapason clamps to from_min/from_max, falling back to min/max', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: 0, max: 100, from_min: 20, from_max: 80 });
+  assert.equal(slider.checkDiapason(10, 20, 80), 20);
+  assert.equal(slider.checkDiapason(90, 20, 80), 80);
+  assert.equal(slider.checkDiapason(50, null, null), 50);
+});
+
+test('checkMinInterval / checkMaxInterval enforce the gap in double mode', (t) => {
+  const { slider } = createSlider(t, '<input>', { type: 'double', min: 0, max: 100, from: 40, to: 60, min_interval: 10, max_interval: 30 });
+  assert.equal(slider.checkMinInterval(55, 60, 'from'), 50);
+  assert.equal(slider.checkMaxInterval(10, 60, 'from'), 30);
+  assert.equal(slider.checkMinInterval(45, 40, 'to'), 50);
+});

--- a/test/unit/helpers.mjs
+++ b/test/unit/helpers.mjs
@@ -1,0 +1,35 @@
+import { JSDOM } from 'jsdom';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const PLUGIN = readFileSync(new URL('../../js/ion.rangeSlider.js', import.meta.url), 'utf8');
+
+/**
+ * Boot jsdom + real jQuery, evaluate the unbuilt plugin inside the window's own
+ * realm, initialise the first <input> and return the instance. Teardown is
+ * registered on the node:test context so a throwing test never leaves the
+ * plugin's 300 ms idle timer alive.
+ *
+ * jsdom has no layout: every width is 0, calc() and drawHandles() return early,
+ * so result.*_percent, labels, grid, onChange and resize are never computed here.
+ * Test the pure methods and the validated options; geometry belongs to Playwright.
+ */
+export function createSlider(t, html, options) {
+  const dom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, {
+    runScripts: 'outside-only',   // without this window.eval is Node's eval and `jQuery` is undefined inside the plugin
+    pretendToBeVisual: true,      // provides requestAnimationFrame
+  });
+  const { window } = dom;
+  const $ = require('jquery')(window);
+  window.jQuery = window.$ = $;
+  window.eval(PLUGIN);
+  const $input = $('input').first();
+  $input.ionRangeSlider(options);
+  const slider = $.data($input[0], 'ionRangeSlider');
+  t.after(() => { if (slider && slider.input) slider.destroy(); window.close(); });
+  return { window, $, $input, slider };
+}
+
+/** Arrays created inside the jsdom realm are not `Array` in ours; compare by value. */
+export const plain = (x) => JSON.parse(JSON.stringify(x));

--- a/test/unit/helpers.mjs
+++ b/test/unit/helpers.mjs
@@ -25,9 +25,10 @@ export function createSlider(t, html, options) {
   window.jQuery = window.$ = $;
   window.eval(PLUGIN);
   const $input = $('input').first();
-  $input.ionRangeSlider(options);
-  const slider = $.data($input[0], 'ionRangeSlider');
+  let slider;
   t.after(() => { if (slider && slider.input) slider.destroy(); window.close(); });
+  $input.ionRangeSlider(options);
+  slider = $.data($input[0], 'ionRangeSlider');
   return { window, $, $input, slider };
 }
 

--- a/test/unit/helpers.test.mjs
+++ b/test/unit/helpers.test.mjs
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSlider } from './helpers.mjs';
+
+test('a throwing constructor still triggers teardown (t.after is registered before ionRangeSlider() runs)', (t) => {
+  // $.extend(config, options) reads every enumerable property of `options`
+  // synchronously inside the IonRangeSlider constructor, well before this.init()
+  // ever runs -- a getter that throws simulates a constructor failure. If
+  // t.after were registered after $input.ionRangeSlider(options) (the bug this
+  // guards against), it would never be reached and window.close() would never run.
+  const boom = Object.defineProperty({}, 'min', {
+    enumerable: true,
+    get() { throw new Error('boom'); },
+  });
+  assert.throws(() => createSlider(t, '<input>', boom), /boom/);
+});

--- a/test/unit/prettify.test.mjs
+++ b/test/unit/prettify.test.mjs
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSlider } from './helpers.mjs';
+
+test('prettify groups thousands with the separator', (t) => {
+  assert.equal(createSlider(t, '<input>', { min: 0, max: 10000000 }).slider.prettify(10000000), '10 000 000');
+  assert.equal(createSlider(t, '<input>', { min: 0, max: 10000, prettify_separator: ',' }).slider.prettify(1234567), '1,234,567');
+});
+
+test('a custom prettify function replaces the default', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: 0, max: 100, prettify: (n) => `<${n}>` });
+  assert.equal(slider._prettify(42), '<42>');
+});
+
+test('decorate adds prefix, postfix and max_postfix only on the max value', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: 0, max: 100, prefix: '$', postfix: 'k', max_postfix: '+' });
+  assert.equal(slider.decorate('50', 50), '$50k');
+  assert.equal(slider.decorate('100', 100), '$100+ k');
+});

--- a/test/unit/validate.test.mjs
+++ b/test/unit/validate.test.mjs
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSlider, plain } from './helpers.mjs';
+
+test('strings are coerced; single mode clamps from but leaves to alone', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: '10', max: '20', from: '5', to: '99', step: '0' });
+  assert.deepEqual([slider.options.min, slider.options.max], [10, 20]);
+  assert.equal(slider.options.from, 10);
+  assert.equal(slider.options.to, 99);      // 2.3.1 only clamps `to` in double mode
+  assert.equal(slider.options.step, 1);     // invalid step falls back to 1
+});
+
+test('double mode clamps both from and to into [min, max]', (t) => {
+  const { slider } = createSlider(t, '<input>', { type: 'double', min: 10, max: 20, from: 5, to: 99 });
+  assert.deepEqual([slider.options.from, slider.options.to], [10, 20]);
+});
+
+test('max below min collapses to min', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: 50, max: 10 });
+  assert.equal(slider.options.max, 50);
+});
+
+test('values mode rewrites min/max/step and prettifies numeric entries', (t) => {
+  const { slider } = createSlider(t, '<input>', { values: ['a', 1000, 'c'] });
+  const o = slider.options;
+  assert.deepEqual([o.min, o.max, o.step, o.grid_snap], [0, 2, 1, true]);
+  assert.deepEqual(plain(o.p_values), ['a', '1 000', 'c']);
+});
+
+test('intervals larger than the range are clamped', (t) => {
+  const { slider } = createSlider(t, '<input>', { type: 'double', min: 0, max: 10, min_interval: 50, max_interval: -3 });
+  assert.equal(slider.options.min_interval, 10);
+  assert.equal(slider.options.max_interval, 0);
+});


### PR DESCRIPTION
## Coverage

- `test/unit/helpers.mjs` — boots jsdom + real jQuery 3.7.1, evaluates the unbuilt `js/ion.rangeSlider.js` inside the window's own realm, initialises the first `<input>`, returns `{ window, $, $input, slider }`. Teardown (`slider.destroy()` + `window.close()`) is registered on the `node:test` context **before** `$input.ionRangeSlider(options)` runs, over a mutable `slider` binding, so a constructor that throws still gets torn down. jsdom has no layout, so geometry (`*_percent`, labels, grid, resize, `onChange`) is out of scope here — a canary test pins `coords.w_rs === 0` for anyone tempted to add geometry assertions to this file; that belongs in the Playwright half.
- `test/unit/helpers.test.mjs` (1) — proves the teardown ordering above: an `options` object with a getter that throws during the constructor's `$.extend(config, options)` still propagates the exception out of `createSlider`, and teardown (`window.close()`) still runs because `t.after` was registered first.
- `test/unit/conversions.test.mjs` (6) — `convertToPercent`/`convertToValue` round-trip, negative min + fractional step, `calcWithStep` grid snapping and 100% clamp, `checkDiapason`, `checkMinInterval`/`checkMaxInterval`.
- `test/unit/validate.test.mjs` (5) — string coercion, single- vs double-mode `from`/`to` clamping, `max < min` collapse, `values` mode rewriting `min`/`max`/`step`/`grid_snap` + `p_values`, interval clamping.
- `test/unit/prettify.test.mjs` (3) — default thousands separator, custom `prettify_separator`, custom `prettify` function, `decorate` prefix/postfix/`max_postfix`.
- `test/unit/config-precedence.test.mjs` (3) — the four-stage config resolution order (defaults → input `value` attribute → JS options → `data-*` attributes), `data-values` comma-splitting, input/`data-from`/instance-handle writeback on init.

18 unit tests, all passing against unmodified 2.3.1 behaviour — no plugin code changed, no `t.todo`.

`package.json` gains `jquery@3.7.1` and `jsdom@^26.1.0` as devDependencies, plus a `test:unit` script; `test` now runs build tests then unit tests. jsdom is pinned to `^26` rather than `^30` because jsdom 30 requires Node 24.15+/22.22+, while 26 supports Node >= 18 with the same API surface this suite uses.

## npm test

```
> ion-rangeslider@2.3.1 test
> npm run test:build && npm run test:unit

# test:build
ℹ tests 6
ℹ pass 6
ℹ fail 0

# test:unit
ℹ tests 18
ℹ pass 18
ℹ fail 0
```

Output is pristine: no jsdom "Not implemented" warnings, nothing on stderr, process exits promptly (no leaked timers).

Refs #796; the Playwright half follows.
