### PR TITLE
Add Playwright smoke tests, a fixture page and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  unit:
+    name: unit (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [22, 24]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  browser:
+    name: browser (${{ matrix.id }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { id: '3.7.1', jquery: 'jquery-3.7.1', slim: '0', projects: '' }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - id: pw
+        run: echo "version=$(node -e 'console.log(require("@playwright/test/package.json").version)')" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+      - run: npx playwright install --with-deps
+      - run: npx playwright test ${{ matrix.projects }}
+        env:
+          IRS_JQUERY: ${{ matrix.jquery }}
+          IRS_SLIM: ${{ matrix.slim }}
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-${{ matrix.id }}
+          path: playwright-report

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
             "version": "2.3.1",
             "license": "MIT",
             "devDependencies": {
+                "@playwright/test": "^1.62.1",
                 "acorn": "^8.15.0",
                 "clean-css": "5.3.3",
                 "jquery": "3.7.1",
+                "jquery-3.7.1": "npm:jquery@^3.7.1",
                 "jsdom": "^26.1.0",
                 "less": "4.9.0",
                 "uglify-js": "3.19.3"
@@ -149,6 +151,22 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@playwright/test": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+            "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.62.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.18.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -272,6 +290,21 @@
             },
             "bin": {
                 "errno": "cli.js"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/graceful-fs": {
@@ -407,6 +440,14 @@
             }
         },
         "node_modules/jquery": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jquery-3.7.1": {
+            "name": "jquery",
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
             "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
@@ -576,6 +617,38 @@
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+            "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.62.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+            "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/probe-image-size": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "acorn": "^8.15.0",
                 "clean-css": "5.3.3",
                 "jquery": "3.7.1",
-                "jquery-3.7.1": "npm:jquery@^3.7.1",
+                "jquery-3.7.1": "npm:jquery@3.7.1",
                 "jsdom": "^26.1.0",
                 "less": "4.9.0",
                 "uglify-js": "3.19.3"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "acorn": "^8.15.0",
         "clean-css": "5.3.3",
         "jquery": "3.7.1",
-        "jquery-3.7.1": "npm:jquery@^3.7.1",
+        "jquery-3.7.1": "npm:jquery@3.7.1",
         "jsdom": "^26.1.0",
         "less": "4.9.0",
         "uglify-js": "3.19.3"

--- a/package.json
+++ b/package.json
@@ -44,12 +44,16 @@
         "build": "node scripts/build.mjs",
         "test": "npm run test:build && npm run test:unit",
         "test:build": "node --test test/build/*.test.mjs",
-        "test:unit": "node --test test/unit/*.test.mjs"
+        "test:unit": "node --test test/unit/*.test.mjs",
+        "test:browser": "playwright test",
+        "test:all": "npm test && npm run test:browser"
     },
     "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "acorn": "^8.15.0",
         "clean-css": "5.3.3",
         "jquery": "3.7.1",
+        "jquery-3.7.1": "npm:jquery@^3.7.1",
         "jsdom": "^26.1.0",
         "less": "4.9.0",
         "uglify-js": "3.19.3"

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,16 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'test/browser',
+  timeout: 20_000,
+  expect: { timeout: 5_000 },
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: { baseURL: 'http://localhost:4173', viewport: { width: 900, height: 500 } },
+  webServer: { command: 'node test/browser/server.mjs', port: 4173, reuseExistingServer: !process.env.CI },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+});

--- a/test/browser/helpers.mjs
+++ b/test/browser/helpers.mjs
@@ -1,0 +1,27 @@
+export const JQUERY = process.env.IRS_JQUERY || 'jquery-3.7.1';
+export const SLIM = process.env.IRS_SLIM === '1';
+export const MIN = process.env.IRS_MIN === '1';
+export const LABEL = `${JQUERY}${SLIM ? ' slim' : ''}${MIN ? ' minified' : ''}`;
+
+export async function open(page, config = {}) {
+  const params = new URLSearchParams({ jquery: JQUERY, config: JSON.stringify(config) });
+  if (SLIM) params.set('slim', '1');
+  if (MIN) params.set('min', '1');
+  await page.goto(`/test/fixtures/slider.html?${params}`);
+  await page.waitForFunction(() => window.__irs && window.__irs.ready);
+}
+
+export const events = (page) => page.evaluate(() => window.__irs.events);
+export const eventTypes = async (page) => (await events(page)).map((e) => e.type);
+export const input = (page) => page.locator('#slider');
+
+/** Drag a handle by a fraction of the line width (positive = right). */
+export async function drag(page, handleSelector, fraction) {
+  const h = await page.locator(handleSelector).boundingBox();
+  const l = await page.locator('.irs-line').boundingBox();
+  const x = h.x + h.width / 2, y = h.y + h.height / 2;
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.mouse.move(x + l.width * fraction, y, { steps: 12 });
+  await page.mouse.up();
+}

--- a/test/browser/server.mjs
+++ b/test/browser/server.mjs
@@ -1,0 +1,22 @@
+// Dependency-free static server for the fixture pages. Serves the repo root so
+// pages can load /js, /css, /node_modules/<jquery alias>/dist and /test/vendor.
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join, normalize } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('../../', import.meta.url));
+const types = { '.html': 'text/html; charset=utf-8', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.map': 'application/json' };
+const port = Number(process.env.PORT || 4173);
+
+createServer(async (req, res) => {
+  const pathname = normalize(decodeURIComponent(new URL(req.url, 'http://localhost').pathname));
+  if (pathname.includes('..')) { res.writeHead(403); return res.end(); }
+  try {
+    const body = await readFile(join(root, pathname));
+    res.writeHead(200, { 'content-type': types[extname(pathname)] || 'application/octet-stream', 'cache-control': 'no-store' });
+    res.end(body);
+  } catch {
+    res.writeHead(404); res.end(`not found: ${pathname}`);
+  }
+}).listen(port, () => console.log(`fixtures at http://localhost:${port}/test/fixtures/slider.html`));

--- a/test/browser/server.mjs
+++ b/test/browser/server.mjs
@@ -6,7 +6,7 @@ import { extname, join, normalize } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const root = fileURLToPath(new URL('../../', import.meta.url));
-const types = { '.html': 'text/html; charset=utf-8', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.map': 'application/json' };
+const types = { '.html': 'text/html; charset=utf-8', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.map': 'application/json' };
 const port = Number(process.env.PORT || 4173);
 
 createServer(async (req, res) => {
@@ -19,4 +19,4 @@ createServer(async (req, res) => {
   } catch {
     res.writeHead(404); res.end(`not found: ${pathname}`);
   }
-}).listen(port, () => console.log(`fixtures at http://localhost:${port}/test/fixtures/slider.html`));
+}).listen(port, '127.0.0.1', () => console.log(`fixtures at http://127.0.0.1:${port}/test/fixtures/slider.html`));

--- a/test/browser/smoke.spec.mjs
+++ b/test/browser/smoke.spec.mjs
@@ -35,11 +35,13 @@ test.describe(`smoke (${LABEL})`, () => {
     await open(page, { min: 0, max: 100, from: 50, step: 5 });
     await page.locator('.irs-line').focus();
     await expect(page.locator('.irs-line')).toBeFocused();
+    const before = (await events(page)).length;   // focus alone already fires onChange+onFinish (#742), so count from here
     await page.keyboard.press('ArrowRight');
     await expect(input(page)).toHaveValue('55');
     await page.keyboard.press('ArrowLeft');
     await expect(input(page)).toHaveValue('50');
-    await expect.poll(() => eventTypes(page)).toContain('onFinish');
+    await expect.poll(async () => (await events(page)).length).toBeGreaterThan(before);
+    expect((await eventTypes(page)).at(-1)).toBe('onFinish');
   });
 
   test('double: two handles, the input holds "from;to", dragging "to" keeps from', async ({ page }) => {
@@ -47,6 +49,8 @@ test.describe(`smoke (${LABEL})`, () => {
     await expect(input(page)).toHaveValue('20;40');
     await drag(page, '.irs-handle.to', 0.4);
     await expect.poll(async () => (await input(page).inputValue()).split(';').map(Number)[1]).toBeGreaterThan(60);
+    const to = Number((await input(page).inputValue()).split(';')[1]);
+    expect(to).toBeLessThan(90);
     expect((await input(page).inputValue()).split(';')[0]).toBe('20');
   });
 

--- a/test/browser/smoke.spec.mjs
+++ b/test/browser/smoke.spec.mjs
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test';
+import { open, events, eventTypes, input, drag, LABEL } from './helpers.mjs';
+
+test.describe(`smoke (${LABEL})`, () => {
+  test('init renders, writes the input and fires onStart once', async ({ page }) => {
+    await open(page, { min: 0, max: 100, from: 30 });
+    await expect(page.locator('.irs--flat')).toHaveCount(1);
+    await expect(input(page)).toHaveValue('30');
+    const ev = await events(page);
+    expect(ev.map((e) => e.type)).toEqual(['onStart']);
+    expect(ev[0]).toMatchObject({ from: 30, min: 0, max: 100 });
+    expect(await page.evaluate(() => window.__irs.jqueryVersion)).toBeTruthy();
+  });
+
+  test('dragging the single handle changes the value, onChange then onFinish', async ({ page }) => {
+    await open(page, { min: 0, max: 100, from: 0 });
+    await drag(page, '.irs-handle.single', 0.5);
+    await expect.poll(async () => Number(await input(page).inputValue())).toBeGreaterThanOrEqual(45);
+    expect(Number(await input(page).inputValue())).toBeLessThanOrEqual(55);
+    const types = await eventTypes(page);
+    expect(types).toContain('onChange');
+    expect(types.at(-1)).toBe('onFinish');
+  });
+
+  test('clicking the line jumps to the clicked value', async ({ page }) => {
+    await open(page, { min: 0, max: 100, from: 0 });
+    const l = await page.locator('.irs-line').boundingBox();
+    await page.mouse.click(l.x + l.width * 0.75, l.y + l.height / 2);
+    await expect.poll(async () => Number(await input(page).inputValue())).toBeGreaterThanOrEqual(70);
+    expect(Number(await input(page).inputValue())).toBeLessThanOrEqual(80);
+    await expect.poll(() => eventTypes(page)).toContain('onFinish');
+  });
+
+  test('keyboard moves by one step and fires onFinish', async ({ page }) => {
+    await open(page, { min: 0, max: 100, from: 50, step: 5 });
+    await page.locator('.irs-line').focus();
+    await expect(page.locator('.irs-line')).toBeFocused();
+    await page.keyboard.press('ArrowRight');
+    await expect(input(page)).toHaveValue('55');
+    await page.keyboard.press('ArrowLeft');
+    await expect(input(page)).toHaveValue('50');
+    await expect.poll(() => eventTypes(page)).toContain('onFinish');
+  });
+
+  test('double: two handles, the input holds "from;to", dragging "to" keeps from', async ({ page }) => {
+    await open(page, { type: 'double', min: 0, max: 100, from: 20, to: 40 });
+    await expect(input(page)).toHaveValue('20;40');
+    await drag(page, '.irs-handle.to', 0.4);
+    await expect.poll(async () => (await input(page).inputValue()).split(';').map(Number)[1]).toBeGreaterThan(60);
+    expect((await input(page).inputValue()).split(';')[0]).toBe('20');
+  });
+
+  test('values mode writes the label, not the index', async ({ page }) => {
+    await open(page, { values: ['S', 'M', 'L', 'XL'], from: 2 });
+    await expect(input(page)).toHaveValue('L');
+    expect((await events(page))[0]).toMatchObject({ from: 2, from_value: 'L' });
+  });
+
+  test('update() rewrites the options, reset() returns to them, destroy() restores the input', async ({ page }) => {
+    await open(page, { min: 0, max: 100, from: 10 });
+    await drag(page, '.irs-handle.single', 0.5);
+    await page.evaluate(() => window.__irs.slider.reset());
+    await expect(input(page)).toHaveValue('10');             // reset undoes the drag
+    await page.evaluate(() => window.__irs.slider.update({ from: 70 }));
+    await expect(input(page)).toHaveValue('70');
+    await expect.poll(() => eventTypes(page)).toContain('onUpdate');
+    await page.evaluate(() => window.__irs.slider.reset());
+    await expect(input(page)).toHaveValue('70');             // update() changed the options themselves
+    await page.evaluate(() => window.__irs.slider.destroy());
+    await expect(page.locator('.irs')).toHaveCount(0);
+    expect(await page.evaluate(() => jQuery.data(document.getElementById('slider'), 'ionRangeSlider'))).toBeFalsy();
+  });
+
+  test('disable shows the mask and disables the input; block keeps the input enabled', async ({ page }) => {
+    await open(page, { min: 0, max: 100, from: 10, disable: true });
+    await expect(page.locator('.irs-disable-mask')).toHaveCount(1);
+    await expect(input(page)).toBeDisabled();
+    await open(page, { min: 0, max: 100, from: 10, block: true });
+    await expect(page.locator('.irs-disable-mask')).toHaveCount(1);
+    await expect(input(page)).toBeEnabled();
+  });
+});

--- a/test/fixtures/slider.html
+++ b/test/fixtures/slider.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>ion.rangeSlider fixture</title>
+<style>body { margin: 40px; } #wrap { width: 600px; }</style>
+</head>
+<body>
+<div id="wrap"><input type="text" id="slider" name="slider"></div>
+<script>
+(function () {
+    var q = {};
+    var parts = location.search.slice(1).split('&');
+    for (var i = 0; i < parts.length; i++) {
+        if (!parts[i]) continue;
+        var kv = parts[i].split('=');
+        q[decodeURIComponent(kv[0])] = decodeURIComponent((kv[1] || '').replace(/\+/g, ' '));
+    }
+    var jq = q.jquery || 'jquery-3.7.1';
+    var jqSrc = jq.indexOf('vendor/') === 0
+        ? '/test/' + jq
+        : '/node_modules/' + jq + '/dist/' + (q.slim === '1' ? 'jquery.slim.js' : 'jquery.js');
+    var min = q.min === '1';
+    window.__irs = { ready: false, events: [], q: q, jquerySrc: jqSrc, min: min };
+    document.write('<link rel="stylesheet" href="/css/ion.rangeSlider' + (min ? '.min' : '') + '.css">');
+    document.write('<script src="' + jqSrc + '"><\/script>');
+    document.write('<script src="/js/ion.rangeSlider' + (min ? '.min' : '') + '.js"><\/script>');
+    window.onload = function () {
+        var config = q.config ? eval('(' + q.config + ')') : {};   // eval: IE8 has no JSON.parse
+        var names = ['onStart', 'onChange', 'onFinish', 'onUpdate'];
+        for (var n = 0; n < names.length; n++) {
+            (function (name) {
+                config[name] = function (data) {
+                    window.__irs.events.push({
+                        type: name, from: data.from, to: data.to, min: data.min, max: data.max,
+                        from_percent: data.from_percent, to_percent: data.to_percent,
+                        from_value: data.from_value, to_value: data.to_value
+                    });
+                };
+            })(names[n]);
+        }
+        jQuery('#slider').ionRangeSlider(config);
+        window.__irs.slider = jQuery.data(document.getElementById('slider'), 'ionRangeSlider');
+        window.__irs.jqueryVersion = jQuery.fn.jquery;
+        window.__irs.ready = true;
+    };
+})();
+</script>
+</body>
+</html>

--- a/test/manual/ie8.md
+++ b/test/manual/ie8.md
@@ -1,0 +1,13 @@
+# Manual IE8 checklist
+
+Run after any change to DOM structure, events, CSS or the UMD wrapper, in an IE8 VM (IE11 in IE8 document mode is a weaker proxy). Start `node test/browser/server.mjs` and open `http://<host>:4173/test/fixtures/slider.html?jquery=vendor/jquery-1.8.3.js` (the fixture itself is written for IE8). Add `&min=1` to check the minified files too.
+
+- [ ] Page loads without a script error dialog (one here means ES5+ syntax slipped into the source or the minified file).
+- [ ] `<html>` has class `lt-ie9`; the slider renders with the flat skin.
+- [ ] Drag the handle: value updates; no text selection happens while dragging.
+- [ ] Click on the line: the handle jumps.
+- [ ] Keyboard: tab to the line, arrows move the handle.
+- [ ] `&config={"type":"double","min":0,"max":100,"from":20,"to":40}`: both handles drag; the input reads `20;40`-style values.
+- [ ] `&config={"disable":true}`: the mask is visible (opacity fallback) and blocks clicks.
+- [ ] `&config={"grid":true}`: grid ticks and labels render.
+- [ ] With F12 tools closed there is no "console is undefined" dialog.


### PR DESCRIPTION
## Summary

Adds a browser test harness for ion.rangeSlider 2.x: a parameterised fixture page (source or minified files, any jQuery build), a dependency-free static server, and eight smoke scenarios run with Playwright across Chromium, Firefox and WebKit. Also adds a manual IE8 checklist (browser automation can't cover IE8) and a GitHub Actions workflow.

## How to run locally

```
npm install
npx playwright install chromium firefox webkit   # or --with-deps on Linux
npm run test:browser        # runs test/browser/smoke.spec.mjs on all 3 engines
npm run test:all            # npm test (build+unit) + npm run test:browser
```

Env vars the fixture/helpers respect: `IRS_JQUERY` (jQuery package alias to load, default `jquery-3.7.1`), `IRS_SLIM=1` (jQuery slim build), `IRS_MIN=1` (load `js/ion.rangeSlider.min.js` + `css/ion.rangeSlider.min.css` instead of the source files).

## CI jobs

- `unit`: `npm test` (build + unit suites) on Node 22 and 24.
- `browser`: Playwright smoke suite on Ubuntu with jQuery 3.7.1, all three engines, cached browser binaries, HTML report uploaded as an artifact.

Task 6 will add a `dist` job; Task 7 will widen the `browser` matrix (jQuery versions, slim build, minified files).

## Test plan

- [x] `npm test` — 24/24 passing (6 build + 18 unit), unchanged.
- [x] `npm run test:browser` — 24/24 passing (8 smoke scenarios × chromium/firefox/webkit).
- [x] `IRS_MIN=1 npx playwright test --project=chromium` against the committed 2019 minified files — 8/8 passing.

Closes #796