### PR TITLE
Script the release procedure

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,12 @@
+# Releasing ion.rangeSlider 2.x
+
+Bugfix or docs only: patch (2.3.2). Additive feature: minor (2.4.0). Never 3.0. Node 22 or newer.
+
+1. `git switch -c release/2.3.2 origin/master` on a clean tree.
+2. `npm run release -- patch` (or `minor`). It bumps every version string, the build counter and the build date (UTC), adds a `history.md` entry and rebuilds `js/` and `css/`.
+3. Replace `#TODO` in `history.md` with the issue numbers the release closes (`gh issue list --milestone 2.3.2 --state all --json number`).
+4. `npm run test:all`, then read `git diff`.
+5. Commit `Release 2.3.2`, push, open the PR, wait for CI. The maintainer merges it, not whoever prepared it.
+6. `git switch master && git pull`, then `git tag 2.3.2 && git push origin 2.3.2` (bare number, no `v`).
+7. `npm pack --dry-run` must list only `js/`, `css/`, `less/`, `readme.md`, `history.md`, `License.md` and `package.json`; then `npm publish`. cdnjs and jsDelivr follow npm.
+8. Close the milestone and the issues it shipped (they stay open until this step on purpose), and move the board's "Next release" view to the next milestone.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,9 +2,9 @@
 
 Bugfix or docs only: patch (2.3.2). Additive feature: minor (2.4.0). Never 3.0. Node 22 or newer.
 
-1. `git switch -c release/2.3.2 origin/master` on a clean tree.
-2. `npm run release -- patch` (or `minor`). It bumps every version string, the build counter and the build date (UTC), adds a `history.md` entry and rebuilds `js/` and `css/`.
-3. Replace `#TODO` in `history.md` with the issue numbers the release closes (`gh issue list --milestone 2.3.2 --state all --json number`).
+1. `git fetch origin`, then `git switch -c release/2.3.2 origin/master` on a clean tree.
+2. `npm run release -- patch` (or `minor`). It bumps every version string, the build counter and the build date (UTC), adds a `history.md` entry and rebuilds `js/` and `css/`. If it errors partway through (for example, the rebuild step fails), run `git checkout -- .` and investigate; the tree is not rolled back automatically.
+3. Replace `#TODO` in `history.md` with the issue numbers the release closes (`gh issue list --milestone 2.3.2 --state all --json number -q '[.[].number] | map("#"+tostring) | join(", ")'`).
 4. `npm run test:all`, then read `git diff`.
 5. Commit `Release 2.3.2`, push, open the PR, wait for CI. The maintainer merges it, not whoever prepared it.
 6. `git switch master && git pull`, then `git tag 2.3.2 && git push origin 2.3.2` (bare number, no `v`).

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
         "test:vendor": "node scripts/verify-vendor.mjs",
         "test:unit": "node --test test/unit/*.test.mjs",
         "test:browser": "playwright test",
-        "test:all": "npm test && npm run test:browser"
+        "test:all": "npm test && npm run test:browser",
+        "release": "node scripts/release.mjs"
     },
     "devDependencies": {
         "@playwright/test": "^1.62.1",

--- a/scripts/lib/bump.mjs
+++ b/scripts/lib/bump.mjs
@@ -19,7 +19,11 @@ export function historyEntry(version, d) {
 
 /** Replace exactly `count` matches of `re` in `text`, or throw naming the site. */
 function must(text, re, replacement, site, count = 1) {
-  const n = (text.match(re) || []).length;
+  // String.match on a non-global regex reports at most 1 regardless of how many times the
+  // pattern occurs, so count with a forced-global copy while replacing with the original
+  // (a non-global re replaces only the first hit, which the count above guarantees is the only one).
+  const countRe = new RegExp(re.source, re.flags.includes('g') ? re.flags : re.flags + 'g');
+  const n = (text.match(countRe) || []).length;
   if (n !== count) throw new Error(`${site} not found (expected ${count} match, got ${n})`);
   return text.replace(re, replacement);
 }

--- a/scripts/lib/bump.mjs
+++ b/scripts/lib/bump.mjs
@@ -1,0 +1,50 @@
+const MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+const two = (n) => String(n).padStart(2, '0');
+const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export function bumpVersion(version, kind) {
+  const [major, minor, patch] = version.split('.').map(Number);
+  if (kind === 'patch') return `${major}.${minor}.${patch + 1}`;
+  if (kind === 'minor') return `${major}.${minor + 1}.0`;
+  throw new Error(`only patch or minor: this line stays 2.x (got "${kind}")`);
+}
+
+export function formatDate(d) {
+  return `${d.getUTCFullYear()}-${two(d.getUTCMonth() + 1)}-${two(d.getUTCDate())} ${two(d.getUTCHours())}:${two(d.getUTCMinutes())}:${two(d.getUTCSeconds())}`;
+}
+
+export function historyEntry(version, d) {
+  return `### Version ${version}. ${MONTHS[d.getUTCMonth()]} ${two(d.getUTCDate())}, ${d.getUTCFullYear()}\n* Issues: #TODO\n\n`;
+}
+
+/** Replace exactly `count` matches of `re` in `text`, or throw naming the site. */
+function must(text, re, replacement, site, count = 1) {
+  const n = (text.match(re) || []).length;
+  if (n !== count) throw new Error(`${site} not found (expected ${count} match, got ${n})`);
+  return text.replace(re, replacement);
+}
+
+/** Pure: takes { path: content } and returns the rewritten contents; throws if any site is missing. */
+export function rewriteFiles({ files, from, to, build, buildDate, entry }) {
+  const f = esc(from);
+  const out = { ...files };
+  let t = out['package.json'];
+  t = must(t, /"version": "[^"]+"/, `"version": "${to}"`, 'package.json: version');
+  t = must(t, /"build": \d+/, `"build": ${build}`, 'package.json: config.build');
+  t = must(t, /"buildDate": "[^"]+"/, `"buildDate": "${buildDate}"`, 'package.json: config.buildDate');
+  out['package.json'] = t;
+  out['bower.json'] = must(out['bower.json'], /"version": "[^"]+"/, `"version": "${to}"`, 'bower.json: version');
+  t = out['js/ion.rangeSlider.js'];
+  t = must(t, /^\/\/ version [^\n]+$/m, `// version ${to} Build: ${build}`, 'js/ion.rangeSlider.js: header');
+  t = must(t, /^\/\/ © Denis Ineshin, \d{4}$/m, `// © Denis Ineshin, ${buildDate.slice(0, 4)}`, 'js/ion.rangeSlider.js: copyright line');
+  t = must(t, /this\.VERSION = "[^"]+";/, `this.VERSION = "${to}";`, 'js/ion.rangeSlider.js: this.VERSION');
+  out['js/ion.rangeSlider.js'] = t;
+  t = out['readme.md'];
+  t = must(t, new RegExp(`^\\* Version: ${f}$`, 'm'), `* Version: ${to}`, 'readme.md: "Version:" line');
+  t = must(t, new RegExp(`archive/${f}\\.zip`), `archive/${to}.zip`, 'readme.md: ZIP link');
+  t = must(t, new RegExp(`ion-rangeslider/${f}/`, 'g'), `ion-rangeslider/${to}/`, 'readme.md: cdnjs URLs', 2);
+  out['readme.md'] = t;
+  out['history.md'] = must(out['history.md'], /^# Update History\n\n/m, `# Update History\n\n${entry}`, 'history.md: heading');
+  const changed = Object.keys(out).filter((p) => out[p] !== files[p]);
+  return { files: out, changed };
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Usage: npm run release -- patch|minor
+// Edits files only: versions, build counter, build date (UTC), history skeleton, then rebuilds.
+// Refuses on a dirty tree and on an unfilled "#TODO" in history.md (a previous release
+// that was never finished). Commit, PR, tag and npm publish are manual: see RELEASING.md.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { bumpVersion, formatDate, historyEntry, rewriteFiles } from './lib/bump.mjs';
+
+const kind = process.argv[2];
+if (!['patch', 'minor'].includes(kind)) {
+  console.error('usage: npm run release -- patch|minor');
+  process.exit(2);
+}
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const dirty = execFileSync('git', ['status', '--porcelain'], { cwd: root, encoding: 'utf8' }).trim();
+if (dirty) { console.error(`working tree is not clean:\n${dirty}`); process.exit(1); }
+const paths = ['package.json', 'bower.json', 'js/ion.rangeSlider.js', 'readme.md', 'history.md'];
+const files = Object.fromEntries(paths.map((p) => [p, readFileSync(resolve(root, p), 'utf8')]));
+if (files['history.md'].includes('#TODO')) { console.error('history.md still has a #TODO entry from an unfinished release'); process.exit(1); }
+const pkg = JSON.parse(files['package.json']);
+const from = pkg.version;
+const to = bumpVersion(from, kind);
+const now = new Date();
+const { files: out, changed } = rewriteFiles({ files, from, to, build: pkg.config.build + 1, buildDate: formatDate(now), entry: historyEntry(to, now) });
+for (const p of changed) writeFileSync(resolve(root, p), out[p]);
+execFileSync('node', [resolve(root, 'scripts/build.mjs')], { stdio: 'inherit' });
+console.log(`\n${from} -> ${to}. Changed: ${changed.join(', ')} plus the built files.\nNext: fill the "Issues:" line in history.md, review git diff, then follow RELEASING.md.`);

--- a/test/build/bump.test.mjs
+++ b/test/build/bump.test.mjs
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { bumpVersion, rewriteFiles, formatDate, historyEntry } from '../../scripts/lib/bump.mjs';
+
+const fixture = () => ({
+  'package.json': '{\n  "version": "2.3.1",\n  "config": {\n    "build": 382,\n    "buildDate": "2019-12-19 16:51:02"\n  }\n}',
+  'bower.json': '{\n    "version": "2.3.1"\n}',
+  'js/ion.rangeSlider.js': '// Ion.RangeSlider\n// version 2.3.1 Build: 382\n// © Denis Ineshin, 2019\n// x\n        this.VERSION = "2.3.1";\n',
+  'readme.md': '* Version: 2.3.1\n* [Download ZIP](https://github.com/IonDen/ion.rangeSlider/archive/2.3.1.zip)\n<link href="https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.3.1/css/ion.rangeSlider.min.css"/>\n<script src="https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.3.1/js/ion.rangeSlider.min.js"></script>\nsome 2.3.1 in prose stays\n',
+  'history.md': '![logo](x.png)\n\n# Update History\n\n### Version 2.3.1. December 19, 2019\n',
+});
+const d = new Date(Date.UTC(2026, 8, 3, 14, 5, 9));
+
+test('bumpVersion', () => {
+  assert.equal(bumpVersion('2.3.1', 'patch'), '2.3.2');
+  assert.equal(bumpVersion('2.3.1', 'minor'), '2.4.0');
+  assert.throws(() => bumpVersion('2.3.1', 'major'), /2\.x/);
+});
+
+test('formatDate (UTC) and historyEntry', () => {
+  assert.equal(formatDate(d), '2026-09-03 14:05:09');
+  assert.equal(historyEntry('2.3.2', d), '### Version 2.3.2. September 03, 2026\n* Issues: #TODO\n\n');
+});
+
+test('rewriteFiles touches every version site and nothing else', () => {
+  const { files: out } = rewriteFiles({ files: fixture(), from: '2.3.1', to: '2.3.2', build: 383, buildDate: '2026-09-03 14:05:09', entry: historyEntry('2.3.2', d) });
+  assert.match(out['package.json'], /"version": "2\.3\.2"/);
+  assert.match(out['package.json'], /"build": 383/);
+  assert.match(out['package.json'], /"buildDate": "2026-09-03 14:05:09"/);
+  assert.match(out['bower.json'], /"version": "2\.3\.2"/);
+  assert.match(out['js/ion.rangeSlider.js'], /^\/\/ version 2\.3\.2 Build: 383$/m);
+  assert.match(out['js/ion.rangeSlider.js'], /^\/\/ © Denis Ineshin, 2026$/m);
+  assert.match(out['js/ion.rangeSlider.js'], /this\.VERSION = "2\.3\.2";/);
+  assert.equal((out['readme.md'].match(/2\.3\.2/g) || []).length, 4);
+  assert.match(out['readme.md'], /some 2\.3\.1 in prose stays/);
+  assert.match(out['history.md'], /# Update History\n\n### Version 2\.3\.2\. September 03, 2026\n\* Issues: #TODO\n\n### Version 2\.3\.1/);
+});
+
+test('rewriteFiles throws when a version site is missing', () => {
+  const files = fixture();
+  files['readme.md'] = 'no version line here\n';
+  assert.throws(() => rewriteFiles({ files, from: '2.3.1', to: '2.3.2', build: 383, buildDate: '2026-09-03 14:05:09', entry: '' }), /readme\.md: "Version:" line not found/);
+});

--- a/test/build/bump.test.mjs
+++ b/test/build/bump.test.mjs
@@ -23,7 +23,8 @@ test('formatDate (UTC) and historyEntry', () => {
 });
 
 test('rewriteFiles touches every version site and nothing else', () => {
-  const { files: out } = rewriteFiles({ files: fixture(), from: '2.3.1', to: '2.3.2', build: 383, buildDate: '2026-09-03 14:05:09', entry: historyEntry('2.3.2', d) });
+  const { files: out, changed } = rewriteFiles({ files: fixture(), from: '2.3.1', to: '2.3.2', build: 383, buildDate: '2026-09-03 14:05:09', entry: historyEntry('2.3.2', d) });
+  assert.deepEqual(changed.slice().sort(), Object.keys(fixture()).sort());
   assert.match(out['package.json'], /"version": "2\.3\.2"/);
   assert.match(out['package.json'], /"build": 383/);
   assert.match(out['package.json'], /"buildDate": "2026-09-03 14:05:09"/);
@@ -40,4 +41,10 @@ test('rewriteFiles throws when a version site is missing', () => {
   const files = fixture();
   files['readme.md'] = 'no version line here\n';
   assert.throws(() => rewriteFiles({ files, from: '2.3.1', to: '2.3.2', build: 383, buildDate: '2026-09-03 14:05:09', entry: '' }), /readme\.md: "Version:" line not found/);
+});
+
+test('rewriteFiles throws when a version site appears more than once', () => {
+  const files = fixture();
+  files['readme.md'] += '* [Download ZIP](https://github.com/IonDen/ion.rangeSlider/archive/2.3.1.zip)\n';
+  assert.throws(() => rewriteFiles({ files, from: '2.3.1', to: '2.3.2', build: 383, buildDate: '2026-09-03 14:05:09', entry: '' }), /readme\.md: ZIP link not found \(expected 1 match, got 2\)/);
 });

--- a/test/build/release.test.mjs
+++ b/test/build/release.test.mjs
@@ -1,0 +1,84 @@
+// Integration coverage for scripts/release.mjs's refusal paths. Each test builds a throwaway
+// git repo under the OS temp dir, copies only release.mjs + lib/bump.mjs into it (release.mjs
+// resolves its own root from import.meta.url, so this copied-into-tmp layout is what makes the
+// run hermetic; it never touches the real checkout), then spawns `node scripts/release.mjs`
+// against it and checks the exit code and stderr. The refusals all fire before build.mjs is
+// invoked, so build.mjs is never copied in and the happy path is out of scope here (that's
+// covered by the manual dry exercise in the release PR, not by this suite).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, readFile, copyFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync, spawnSync } from 'node:child_process';
+
+const PATHS = ['package.json', 'bower.json', 'js/ion.rangeSlider.js', 'readme.md', 'history.md'];
+
+const fixture = () => ({
+  'package.json': '{\n  "version": "2.3.1",\n  "config": {\n    "build": 382,\n    "buildDate": "2019-12-19 16:51:02"\n  }\n}',
+  'bower.json': '{\n    "version": "2.3.1"\n}',
+  'js/ion.rangeSlider.js': '// Ion.RangeSlider\n// version 2.3.1 Build: 382\n// © Denis Ineshin, 2019\n// x\n        this.VERSION = "2.3.1";\n',
+  'readme.md': '* Version: 2.3.1\n* [Download ZIP](https://github.com/IonDen/ion.rangeSlider/archive/2.3.1.zip)\n<link href="https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.3.1/css/ion.rangeSlider.min.css"/>\n<script src="https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.3.1/js/ion.rangeSlider.min.js"></script>\nsome 2.3.1 in prose stays\n',
+  'history.md': '![logo](x.png)\n\n# Update History\n\n### Version 2.3.1. December 19, 2019\n',
+});
+
+/** Creates a throwaway git repo with a copy of release.mjs + lib/bump.mjs and the five source
+ * files, commits it, and registers cleanup on `t`. Returns { dir, files }. */
+async function withScratchRepo(t, { historyTodo = false } = {}) {
+  const dir = await mkdtemp(join(tmpdir(), 'ion-release-test-'));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  await mkdir(join(dir, 'scripts', 'lib'), { recursive: true });
+  await mkdir(join(dir, 'js'), { recursive: true });
+  await copyFile(fileURLToPath(new URL('../../scripts/release.mjs', import.meta.url)), join(dir, 'scripts', 'release.mjs'));
+  await copyFile(fileURLToPath(new URL('../../scripts/lib/bump.mjs', import.meta.url)), join(dir, 'scripts', 'lib', 'bump.mjs'));
+  const files = fixture();
+  if (historyTodo) files['history.md'] = files['history.md'].replace(/\n$/, '') + '\n* Issues: #TODO\n';
+  for (const rel of PATHS) await writeFile(join(dir, rel), files[rel]);
+  execFileSync('git', ['init', '-q'], { cwd: dir, stdio: 'ignore' });
+  execFileSync('git', ['add', '-A'], { cwd: dir, stdio: 'ignore' });
+  execFileSync('git', ['-c', 'user.email=test@test', '-c', 'user.name=test', 'commit', '-q', '-m', 'init'], { cwd: dir, stdio: 'ignore' });
+  return { dir, files };
+}
+
+function runRelease(dir, args) {
+  return spawnSync(process.execPath, ['scripts/release.mjs', ...args], { cwd: dir, encoding: 'utf8' });
+}
+
+async function readAll(dir) {
+  const out = {};
+  for (const rel of PATHS) out[rel] = await readFile(join(dir, rel), 'utf8');
+  return out;
+}
+
+test('release.mjs refusal paths', async (t) => {
+  await t.test('missing or invalid arg: exit 2 with the usage line', async (t) => {
+    const { dir } = await withScratchRepo(t);
+    const missing = runRelease(dir, []);
+    assert.equal(missing.status, 2);
+    assert.match(missing.stderr, /usage: npm run release -- patch\|minor/);
+    const bad = runRelease(dir, ['major']);
+    assert.equal(bad.status, 2);
+    assert.match(bad.stderr, /usage: npm run release -- patch\|minor/);
+  });
+
+  await t.test('dirty tree: exit 1, refuses, and leaves every file untouched', async (t) => {
+    const { dir } = await withScratchRepo(t);
+    const readme = await readFile(join(dir, 'readme.md'), 'utf8');
+    await writeFile(join(dir, 'readme.md'), readme + 'uncommitted local edit\n');
+    const before = await readAll(dir);
+    const result = runRelease(dir, ['patch']);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /working tree is not clean/);
+    assert.deepEqual(await readAll(dir), before);
+  });
+
+  await t.test('unfinished release (#TODO in history.md): exit 1, refuses, and leaves every file untouched', async (t) => {
+    const { dir } = await withScratchRepo(t, { historyTodo: true });
+    const before = await readAll(dir);
+    const result = runRelease(dir, ['patch']);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /history\.md still has a #TODO entry from an unfinished release/);
+    assert.deepEqual(await readAll(dir), before);
+  });
+});


### PR DESCRIPTION
Adds `scripts/release.mjs` and `scripts/lib/bump.mjs`, run via `npm run release -- patch|minor`. It rewrites every version string across `package.json`, `bower.json`, `js/ion.rangeSlider.js`, `readme.md` and `history.md`, bumps the build counter and build date (UTC), adds a `history.md` entry with an `#TODO` issues placeholder, and rebuilds the shipped `js/`/`css/` files via the existing build script.

It refuses to run on a dirty working tree, and refuses if `history.md` still has an unfilled `#TODO` entry from a previous release that was never finished.

Also adds `RELEASING.md`, the step-by-step release checklist (branch, run the release script, fill in the issue numbers, test, commit, PR, tag, `npm publish`, close the milestone). Commit, tag and npm publish stay manual on purpose.

Covered by new tests in `test/build/bump.test.mjs` (bumpVersion, formatDate, historyEntry, rewriteFiles success and failure paths), run via `npm run test:build`.

Closes #795