### PR TITLE
Make the readme defaults table match the code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,7 @@ Or use `data-*` attributes on the input:
 | `prettify` | `-` | `null` | function | Custom formatting function. Receives a number, returns a string |
 | `force_edges` | `data-force-edges` | `false` | boolean | Keep handles and tooltips inside the container |
 | `keyboard` | `data-keyboard` | `true` | boolean | Keyboard controls. Left: ←, ↓, A, S. Right: →, ↑, W, D |
-| `grid` | `data-grid` | `true` | boolean | Show grid of values above the slider |
+| `grid` | `data-grid` | `false` | boolean | Show grid of values above the slider |
 | `grid_margin` | `data-grid-margin` | `true` | boolean | Add left and right grid gaps |
 | `grid_num` | `data-grid-num` | `4` | number | Number of grid units |
 | `grid_snap` | `data-grid-snap` | `false` | boolean | Snap grid to step. When active, grid_num is not used. Max 50 steps |
@@ -155,8 +155,8 @@ Or use `data-*` attributes on the input:
 | `postfix` | `data-postfix` | `` | string | Postfix for values: 100**k** |
 | `max_postfix` | `data-max-postfix` | `` | string | Postfix for the maximum value only: 0 — 100**+** |
 | `decorate_both` | `data-decorate-both` | `true` | boolean | How to format close values in double mode: **$10k — $100k** vs **$10 — 100k** |
-| `values_separator` | `data-values-separator` | ` - ` | string | Separator between from and to labels in double mode |
-| `input_values_separator` | `data-input-values-separator` | ` ; ` | string | Separator in the input value for double mode: `<input value="25;42">` |
+| `values_separator` | `data-values-separator` | ` — ` | string | Separator between from and to labels in double mode |
+| `input_values_separator` | `data-input-values-separator` | `;` | string | Separator in the input value for double mode: `<input value="25;42">` |
 | `disable` | `data-disable` | `false` | boolean | Disable the slider. Input is also disabled and invisible to forms |
 | `block` | `data-block` | `false` | boolean | Block the slider but keep the input enabled. Value is still submitted with the form |
 | `extra_classes` | `data-extra-classes` | `—` | string | Extra CSS classes for the slider container |


### PR DESCRIPTION
Fixes the readme options table Defaults column so it matches the `config` defaults object in `js/ion.rangeSlider.js`. Docs-only change.

## Before / after

| Option | Before | After | Code |
| --- | --- | --- | --- |
| `grid` | `true` | `false` | `grid: false` |
| `values_separator` | ` - ` (hyphen) | ` — ` (em dash) | `values_separator: " — "` |
| `input_values_separator` | ` ; ` (spaces) | `;` | `input_values_separator: ";"` |

Every other row in the table was audited against the config defaults and already matches (including `from`/`to`/`from_min`/`from_max`/`to_min`/`to_max`, which document the effective min/max fallback rather than the literal `null` default — confirmed against `validate()` and `checkDiapason`).

Table formatting/style and all descriptions are untouched.

Closes #799