### PR TITLE
Publish to npm from CI via trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,16 @@
 #
 # One-time prerequisite (maintainer, on npmjs.com): package Settings ->
 # Trusted Publisher -> GitHub Actions, with owner "IonDen", repository
-# "ion.rangeSlider" and workflow filename "publish.yml". Until that is
-# configured, `npm publish` below will fail with an auth error.
+# "ion.rangeSlider", workflow filename "publish.yml", Allowed actions
+# "npm publish", and the Environment field left empty (this workflow
+# does not declare a GitHub Actions environment; setting one here makes
+# npm reject the publish). Until that is configured, `npm publish`
+# below will fail with an auth error.
+#
+# actions/checkout and actions/setup-node are pinned to a commit SHA
+# (not just the v4 tag ci.yml/jquery-matrix.yml use) because this job
+# carries id-token: write, which can mint short-lived OIDC credentials -
+# only the publish path needs that extra supply-chain hardening.
 #
 # Normal release: pushing a release tag (bare number, e.g. "2.3.2") runs
 # this automatically. To publish a tag that was already pushed (for
@@ -35,18 +43,34 @@ jobs:
     env:
       RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_TAG }}
+      - name: Validate the release tag
+        run: |
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "RELEASE_TAG is empty (no tag on the triggering push and no dispatch input)." >&2
+            exit 1
+          fi
+          if ! echo "$RELEASE_TAG" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "RELEASE_TAG '$RELEASE_TAG' is not a bare release number (expected e.g. 2.3.2)." >&2
+            exit 1
+          fi
 
-      - uses: actions/setup-node@v4
+      # Tag-qualified: an unqualified ref resolves branch-before-tag, so
+      # a branch that happened to share a release's name would silently
+      # get checked out (and published) instead of the tag.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: refs/tags/${{ env.RELEASE_TAG }}
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       # Trusted publishing needs npm >= 11.5.1; the node-version above
       # bundles an older npm, so upgrade it before anything else runs.
-      - run: npm install -g npm@latest
+      # Major-pinned, not @latest: no floating code in the job that
+      # holds id-token: write.
+      - run: npm install -g npm@11
       - run: npm --version
 
       - run: npm ci
@@ -62,6 +86,12 @@ jobs:
             }
             console.log('package.json version matches tag ' + tag);
           "
+
+      # ci.yml's "committed dist is up to date" job does not run on tag
+      # pushes, so this is the last check before a stale dist reaches
+      # the registry.
+      - run: npm run build
+      - run: git diff --exit-code -- js css
 
       - run: npm test
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,68 @@
+# Publishes ion-rangeslider to npm using trusted publishing (OIDC) - no
+# npm token or repo secret is used or referenced here. Provenance is
+# generated automatically by npm when publishing this way.
+#
+# One-time prerequisite (maintainer, on npmjs.com): package Settings ->
+# Trusted Publisher -> GitHub Actions, with owner "IonDen", repository
+# "ion.rangeSlider" and workflow filename "publish.yml". Until that is
+# configured, `npm publish` below will fail with an auth error.
+#
+# Normal release: pushing a release tag (bare number, e.g. "2.3.2") runs
+# this automatically. To publish a tag that was already pushed (for
+# example the first run after configuring trusted publishing), dispatch
+# this workflow manually with that tag:
+#   gh workflow run publish.yml -f tag=2.3.2
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. 2.3.2)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing needs npm >= 11.5.1; the node-version above
+      # bundles an older npm, so upgrade it before anything else runs.
+      - run: npm install -g npm@latest
+      - run: npm --version
+
+      - run: npm ci
+
+      - name: Verify package.json version matches the release tag
+        run: |
+          node -e "
+            var v = require('./package.json').version;
+            var tag = process.env.RELEASE_TAG;
+            if (v !== tag) {
+              console.error('package.json version \"' + v + '\" does not match release tag \"' + tag + '\"');
+              process.exit(1);
+            }
+            console.log('package.json version matches tag ' + tag);
+          "
+
+      - run: npm test
+
+      - run: npm publish

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,13 +2,20 @@
 
 Bugfix or docs only: patch (2.3.2). Additive feature: minor (2.4.0). Never 3.0. Node 22 or newer.
 
-Prerequisite, one time only: the npm trusted publisher for `ion-rangeslider` must be configured on npmjs.com (package Settings -> Trusted Publisher -> GitHub Actions, owner `IonDen`, repository `ion.rangeSlider`, workflow `publish.yml`). Publishing is otherwise handled by `.github/workflows/publish.yml` and needs no npm token or repo secret.
+Prerequisite, one time only: configure the npm trusted publisher for `ion-rangeslider` on npmjs.com (package Settings -> Trusted Publisher -> GitHub Actions), with:
+- Organization or user: `IonDen`
+- Repository: `ion.rangeSlider`
+- Workflow filename: `publish.yml`
+- Environment name: leave empty. The workflow declares no GitHub Actions environment; setting one here makes npm reject its publishes.
+- Allowed actions: `npm publish`
+
+Publishing is otherwise handled by `.github/workflows/publish.yml` and needs no npm token or repo secret. Once a trusted-publishing release has gone through cleanly, harden the package on npmjs.com: set publishing access to require 2FA and disallow classic tokens.
 
 1. `git fetch origin`, then `git switch -c release/2.3.2 origin/master` on a clean tree.
 2. `npm run release -- patch` (or `minor`). It bumps every version string, the build counter and the build date (UTC), adds a `history.md` entry and rebuilds `js/` and `css/`. If it errors partway through (for example, the rebuild step fails), run `git checkout -- .` and investigate; the tree is not rolled back automatically.
 3. Replace `#TODO` in `history.md` with the issue numbers the release closes (`gh issue list --milestone 2.3.2 --state all --json number -q '[.[].number] | sort | map("#"+tostring) | join(", ")'`).
-4. `npm run test:all`, then read `git diff`.
+4. `npm run test:all`, then read `git diff`. `npm pack --dry-run` is worth a look too: it should list only `js/`, `css/`, `less/`, `readme.md`, `history.md`, `License.md` and `package.json`.
 5. Commit `Release 2.3.2`, push, open the PR, wait for CI. The maintainer merges it, not whoever prepared it.
 6. `git switch master && git pull`, then `git tag 2.3.2 && git push origin 2.3.2` (bare number, no `v`). The tag push triggers `publish.yml`, which checks the tag against `package.json`, runs the tests and publishes with provenance via trusted publishing. If the tag was already pushed and the workflow needs to be run by hand (for example the first release after configuring trusted publishing), dispatch it instead: `gh workflow run publish.yml -f tag=2.3.2`.
-7. Watch the run (`gh run watch` or the Actions tab) until `npm publish` succeeds. `npm pack --dry-run` locally beforehand is still useful to sanity-check the file list (`js/`, `css/`, `less/`, `readme.md`, `history.md`, `License.md` and `package.json`). cdnjs and jsDelivr follow npm.
+7. Watch the run (`gh run watch` or the Actions tab) until `npm publish` succeeds. cdnjs and jsDelivr follow npm.
 8. Close the milestone and the issues it shipped (they stay open until this step on purpose), and move the board's "Next release" view to the next milestone.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,11 +2,13 @@
 
 Bugfix or docs only: patch (2.3.2). Additive feature: minor (2.4.0). Never 3.0. Node 22 or newer.
 
+Prerequisite, one time only: the npm trusted publisher for `ion-rangeslider` must be configured on npmjs.com (package Settings -> Trusted Publisher -> GitHub Actions, owner `IonDen`, repository `ion.rangeSlider`, workflow `publish.yml`). Publishing is otherwise handled by `.github/workflows/publish.yml` and needs no npm token or repo secret.
+
 1. `git fetch origin`, then `git switch -c release/2.3.2 origin/master` on a clean tree.
 2. `npm run release -- patch` (or `minor`). It bumps every version string, the build counter and the build date (UTC), adds a `history.md` entry and rebuilds `js/` and `css/`. If it errors partway through (for example, the rebuild step fails), run `git checkout -- .` and investigate; the tree is not rolled back automatically.
 3. Replace `#TODO` in `history.md` with the issue numbers the release closes (`gh issue list --milestone 2.3.2 --state all --json number -q '[.[].number] | sort | map("#"+tostring) | join(", ")'`).
 4. `npm run test:all`, then read `git diff`.
 5. Commit `Release 2.3.2`, push, open the PR, wait for CI. The maintainer merges it, not whoever prepared it.
-6. `git switch master && git pull`, then `git tag 2.3.2 && git push origin 2.3.2` (bare number, no `v`).
-7. `npm pack --dry-run` must list only `js/`, `css/`, `less/`, `readme.md`, `history.md`, `License.md` and `package.json`; then `npm publish`. cdnjs and jsDelivr follow npm.
+6. `git switch master && git pull`, then `git tag 2.3.2 && git push origin 2.3.2` (bare number, no `v`). The tag push triggers `publish.yml`, which checks the tag against `package.json`, runs the tests and publishes with provenance via trusted publishing. If the tag was already pushed and the workflow needs to be run by hand (for example the first release after configuring trusted publishing), dispatch it instead: `gh workflow run publish.yml -f tag=2.3.2`.
+7. Watch the run (`gh run watch` or the Actions tab) until `npm publish` succeeds. `npm pack --dry-run` locally beforehand is still useful to sanity-check the file list (`js/`, `css/`, `less/`, `readme.md`, `history.md`, `License.md` and `package.json`). cdnjs and jsDelivr follow npm.
 8. Close the milestone and the issues it shipped (they stay open until this step on purpose), and move the board's "Next release" view to the next milestone.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "files": ["js/", "css/", "less/", "readme.md", "history.md", "License.md"],
     "repository": {
         "type": "git",
-        "url": "git://github.com/IonDen/ion.rangeSlider.git"
+        "url": "git+https://github.com/IonDen/ion.rangeSlider.git"
     },
     "bugs": {
         "url": "https://github.com/IonDen/ion.rangeSlider/issues"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish.yml`, a GitHub Actions workflow that publishes `ion-rangeslider` to npm using npm's trusted publishing (OIDC). No npm token or repository secret is used anywhere in the workflow; npm generates provenance attestations automatically for this publish path.

The workflow triggers on push of a bare-number release tag (`[0-9]+.[0-9]+.[0-9]+`, matched only against tag refs so it cannot fire on a branch push) or on `workflow_dispatch` with a required `tag` input, for publishing a tag that was already pushed. It validates that input, checks out the tag (ref-qualified as `refs/tags/<tag>` so an unqualified ref can't resolve to a same-named branch instead), upgrades npm in the runner (Node 22's bundled npm predates the >=11.5.1 trusted-publishing requirement, pinned to the `npm@11` line rather than `@latest`), runs `npm ci`, gates on `package.json`'s version exactly matching the tag, rebuilds and diffs `js`/`css` against what's committed (tag pushes skip `ci.yml`'s own dist-parity job), runs `npm test`, then `npm publish`. `actions/checkout` and `actions/setup-node` are pinned to a commit SHA rather than the `v4` tag `ci.yml`/`jquery-matrix.yml` use, since this is the one job in the repo that carries `id-token: write`.

`package.json`'s `repository.url` is normalized from `git://github.com/IonDen/ion.rangeSlider.git` to `git+https://github.com/IonDen/ion.rangeSlider.git` — npm's trusted-publisher repo match is documented against the GitHub repository, and `git+https` is the form that's unambiguous to it.

`RELEASING.md` is updated: the release procedure now ends at the tag push (which triggers the workflow) instead of a manual local `npm pack --dry-run` + `npm publish`, moves the `npm pack --dry-run` sanity check to before the release commit (it was previously worded as a post-tag step with a dangling "beforehand"), documents every field of the one-time npm trusted-publisher setup, and adds a post-first-publish hardening note (require 2FA, disallow tokens). The milestone/issue-closing step is unchanged.

## Maintainer one-time setup (required before this can publish)

On npmjs.com: package `ion-rangeslider` -> Settings -> Trusted Publisher -> GitHub Actions, with:
- Organization or user: `IonDen`
- Repository: `ion.rangeSlider`
- Workflow filename: `publish.yml`
- Environment name: leave empty. This workflow declares no GitHub Actions environment; setting one here makes npm reject its publishes.
- Allowed actions: `npm publish`

Until that's configured, any run of this workflow will fail at the `npm publish` step with an auth error. The workflow file itself references no secret, so there is nothing else to configure on the GitHub side beyond the `id-token: write` permission already declared in the workflow. Once the first trusted-publishing release goes through cleanly, tighten the package on npmjs.com: require 2FA for publishing and disallow classic tokens.

## Known first-run caveat

The `2.3.2` tag already on origin was cut before this PR, so its tree still carries the old `git://...` `repository.url` — tags are immutable, so that can't be fixed retroactively. If npm's repo-match rejects the trusted-publish attempt against that tag for this reason, the fallback is one last manual `npm publish` of `2.3.2` from a local checkout with a valid npm token; trusted publishing would then own `2.4.0` onward, whose tag will carry the corrected `git+https` URL from this PR.

## How 2.3.2 will be published

npm still has `2.3.1` live. After this PR merges and the trusted-publisher setup above is done, publish 2.3.2 by dispatching the workflow by hand against the existing tag:

```
gh workflow run publish.yml -f tag=2.3.2
```

This PR does not dispatch that run. See "Known first-run caveat" above for the fallback if that dispatch fails on the repository-url mismatch.

## Test plan

- [x] `npm test` passes locally (build/packaging/vendor/unit checks unaffected; this PR adds no tests since the workflow's logic is CI-only)
- [x] `.github/workflows/publish.yml` parses as valid YAML (verified with the `js-yaml` CLI, both before and after the hardening commit)
- [x] Verified the release-tag validation step and the version-gate `node -e` step's exact shell quoting by extracting each verbatim from the parsed YAML and running it standalone: valid tag, empty tag, `v`-prefixed tag, branch-shaped tag, and a suffixed tag all fail/pass as intended; the version gate passes on a matching tag and fails clearly on a mismatch
- [x] Confirmed `actions/checkout`/`actions/setup-node` SHAs resolve to the exact commits the `v4` tag currently points to (`v4.4.0` for both, via `gh api repos/<owner>/<repo>/tags`)
- [x] Ran `npm run build` + `git diff --exit-code -- js css` locally after the `repository.url` change to confirm it doesn't touch built output (banners derive only from version/date) — no diff
- [x] Diff scope confirmed: `.github/workflows/publish.yml` (new), `RELEASING.md` and `package.json` (edited); no unintended dist changes
- [ ] First live dispatch against tag `2.3.2`, after the npm-side trusted-publisher setup (maintainer, not part of this PR)

Refs #827 (closes when the first automated publish is live)
