### PR TITLE
Add regression tests for focus never changing the value

### DIFF
--- a/test/browser/smoke.spec.mjs
+++ b/test/browser/smoke.spec.mjs
@@ -106,6 +106,90 @@ test.describe(`smoke (${LABEL})`, () => {
     expect((await events(page)).length).toBe(before);
   });
 
+  // #557 / #577: the #742 tests above pin CALLBACKS only, starting from an
+  // ON-GRID value (from: 30, step not set / divides cleanly) -- they never
+  // exercise the actual #557/#577 symptom, which is the pre-#742
+  // pointerFocus() also mutating the VALUE. Before #742, pointerFocus()
+  // synthesized a click at the handle's own on-screen position whenever
+  // this.target was null, and that click ran calc()/calcWithStep(): an
+  // off-grid initial value got step-snapped, and at narrow slider widths a
+  // fractional value could round differently through the click's
+  // pixel<->value round trip. #742 (commit ee29de2) reduced pointerFocus()
+  // to arming keyboard state only, so all three tests below are green both
+  // before and after that fix (characterization pins), proven by the
+  // mutation-evidence protocol (reinstating the pre-#742 body from commit
+  // 40b1ceb) rather than red-first, since the fix already shipped in 2.4.0.
+
+  /**
+   * Real keyboard Tab from document.body to the slider's `.irs-line`,
+   * mirroring #557's actual repro (tabbing out of a preceding field, or
+   * into the slider from nothing) rather than a programmatic .focus() call.
+   * The fixture page has no other tabbable element -- toggleInput() forces
+   * the real (hidden) input's tabindex to -1 on init -- so a single press
+   * normally reaches it; loop defensively in case that ever changes.
+   */
+  async function tabToLine(page) {
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press('Tab');
+      if (await page.locator('.irs-line').evaluate((el) => el === document.activeElement)) {
+        return;
+      }
+    }
+  }
+
+  // #557: an off-grid initial value (from: 33, step: 10 -- validate() never
+  // step-snaps from/to at init) must stay exactly as given after a real Tab
+  // lands focus on the slider, with no onChange/onFinish. Mutation this
+  // catches: reinstating the pre-#742 pointerFocus() synthesized click,
+  // which step-snaps 33 to the nearest multiple of 10 (30) and fires
+  // onChange then onFinish for a value the user never touched.
+  test('tabbing onto the slider does not snap an off-grid value or fire onChange (#557)', async ({ page }) => {
+    await open(page, { min: 0, max: 100, from: 33, step: 10 });
+    await tabToLine(page);
+    await expect(page.locator('.irs-line')).toBeFocused();
+    // Outlast the 300ms idle render poll -- the only place a
+    // focus-triggered force_redraw would actually reach drawHandles() and
+    // fire callbacks.
+    await page.waitForTimeout(400);
+    await expect(page.locator('.irs-single')).toHaveText('33');
+    await expect(input(page)).toHaveValue('33');
+    expect(await eventTypes(page)).toEqual(['onStart']);
+  });
+
+  // #577's exact report: step: 0.1, from: 2.9, slider width <= 325px --
+  // tabbing to the slider rounded the value to 3.0. Same pointerFocus()
+  // root cause as #557, but this is the narrow-width / fractional-step
+  // shape: calcWithStep()'s pixel<->value round trip on the synthesized
+  // click's screen position rounds more coarsely at a narrow width than at
+  // this fixture's 600px default. The width param is additive (test/
+  // fixtures/slider.html, #577).
+  test('tabbing onto a narrow slider does not round a fractional value or fire onChange (#577)', async ({ page }) => {
+    await open(page, { min: 0, max: 10, from: 2.9, step: 0.1 }, { width: '300' });
+    await tabToLine(page);
+    await expect(page.locator('.irs-line')).toBeFocused();
+    await page.waitForTimeout(400);
+    await expect(page.locator('.irs-single')).toHaveText('2.9');
+    await expect(input(page)).toHaveValue('2.9');
+    expect(await eventTypes(page)).toEqual(['onStart']);
+  });
+
+  // #557 in double mode: the pre-#742 pointerFocus() always targeted "from"
+  // ($handle = this.$cache.from whenever type !== "single"), so its
+  // synthesized click only ever snapped "from"; "to" was untouched. Pin
+  // exactly that asymmetric shape -- it documents the old default target,
+  // not a full double-mode #557 repro -- with a programmatic .focus() (the
+  // #557 report itself also names programmatic focus, not just Tab).
+  test('double: programmatic focus does not snap "from" or fire onChange (#557)', async ({ page }) => {
+    await open(page, { type: 'double', min: 0, max: 100, from: 33, to: 67, step: 10 });
+    await page.locator('.irs-line').focus();
+    await expect(page.locator('.irs-line')).toBeFocused();
+    await page.waitForTimeout(400);
+    await expect(page.locator('.irs-from')).toHaveText('33');
+    await expect(page.locator('.irs-to')).toHaveText('67');
+    await expect(input(page)).toHaveValue('33;67');
+    expect(await eventTypes(page)).toEqual(['onStart']);
+  });
+
   test('keyboard moves by one step and fires onFinish', async ({ page }) => {
     await open(page, { min: 0, max: 100, from: 50, step: 5 });
     await page.locator('.irs-line').focus();

--- a/test/browser/smoke.spec.mjs
+++ b/test/browser/smoke.spec.mjs
@@ -188,8 +188,12 @@ test.describe(`smoke (${LABEL})`, () => {
     // cover. `.irs` is the exact element the plugin measures for all
     // pixel<->value conversion (this.$cache.rs / coords.w_rs), so pinning
     // its rendered width here ties the guard to the mechanism the rest of
-    // the test depends on.
-    const box = await page.locator('.irs').boundingBox();
+    // the test depends on. The outer container span also carries the
+    // "irs" class (js/ion.rangeSlider.js `append()`), so a bare `.irs`
+    // locator matches two elements and hits a strict-mode violation;
+    // scope to the inner descendant that $cache.rs actually is -- the
+    // fixture renders a single slider, always instance 0.
+    const box = await page.locator('.js-irs-0 .irs').boundingBox();
     expect(box.width).toBe(300);
     await tabToLine(page);
     await expect(page.locator('.irs-line')).toBeFocused();

--- a/test/browser/smoke.spec.mjs
+++ b/test/browser/smoke.spec.mjs
@@ -106,19 +106,27 @@ test.describe(`smoke (${LABEL})`, () => {
     expect((await events(page)).length).toBe(before);
   });
 
-  // #557 / #577: the #742 tests above pin CALLBACKS only, starting from an
-  // ON-GRID value (from: 30, step not set / divides cleanly) -- they never
-  // exercise the actual #557/#577 symptom, which is the pre-#742
-  // pointerFocus() also mutating the VALUE. Before #742, pointerFocus()
-  // synthesized a click at the handle's own on-screen position whenever
-  // this.target was null, and that click ran calc()/calcWithStep(): an
-  // off-grid initial value got step-snapped, and at narrow slider widths a
-  // fractional value could round differently through the click's
-  // pixel<->value round trip. #742 (commit ee29de2) reduced pointerFocus()
-  // to arming keyboard state only, so all three tests below are green both
-  // before and after that fix (characterization pins), proven by the
-  // mutation-evidence protocol (reinstating the pre-#742 body from commit
-  // 40b1ceb) rather than red-first, since the fix already shipped in 2.4.0.
+  // #557 / #577: the two #742 focus tests above pin CALLBACKS only, on an
+  // ON-GRID value (from: 30, step not set) -- they never exercise the
+  // actual #557/#577 symptom, which is the pre-#742 pointerFocus() also
+  // mutating the VALUE (the third #742 test, "clicking the line near the
+  // current value", does assert a value, but that is a deliberate click,
+  // not focus alone). Before #742, pointerFocus() synthesized a click that
+  // read the handle's own on-screen position back through the pixel<->value
+  // conversion, and that introduced a small positional bias -- one that
+  // grows as the slider gets narrower. The synthesized click always fired
+  // onChange/onFinish, but whether the reported VALUE visibly moved
+  // depended on the step size relative to that bias: an off-grid value on a
+  // coarse step snapped straight onto the grid regardless of width (33 ->
+  // 30 at step 10), while a value already sitting on a fine step only moved
+  // once the slider was narrow enough for the bias to cross half a step
+  // (2.9 -> "3" at step 0.1 -- see the measured width sweep on the #577
+  // test below). #742 (commit ee29de2) reduced pointerFocus() to arming
+  // keyboard state only, so all three tests below are green both before and
+  // after that fix (characterization pins), proven by the mutation-evidence
+  // protocol -- reinstating the 2.3.2-era focus handler (any commit before
+  // ee29de2; copied here from 40b1ceb) -- rather than red-first, since the
+  // fix already shipped in 2.4.0.
 
   /**
    * Real keyboard Tab from document.body to the slider's `.irs-line`,
@@ -156,15 +164,33 @@ test.describe(`smoke (${LABEL})`, () => {
     expect(await eventTypes(page)).toEqual(['onStart']);
   });
 
-  // #577's exact report: step: 0.1, from: 2.9, slider width <= 325px --
-  // tabbing to the slider rounded the value to 3.0. Same pointerFocus()
-  // root cause as #557, but this is the narrow-width / fractional-step
-  // shape: calcWithStep()'s pixel<->value round trip on the synthesized
-  // click's screen position rounds more coarsely at a narrow width than at
-  // this fixture's 600px default. The width param is additive (test/
-  // fixtures/slider.html, #577).
+  // #577: mirrors the report's step (0.1) and from (2.9) at a width inside
+  // its stated "<= 325px" range -- the report's own fiddle used min 1..10,
+  // this fixture keeps min 0..10, so this is the report's step and a width
+  // inside its stated range, not a byte-for-byte reproduction. Measured
+  // against the mutation below across a width sweep: the synthesized
+  // click's positional bias (see the header comment above) is too small to
+  // move 2.9 off its own step at 600px or 400px; from 326px down to 200px
+  // it crosses half a step and the value becomes "3" (the fixture renders
+  // "3", not "3.0" -- same numeric value as the report, and roughly
+  // matching its own "<= 325px" threshold); at 100px it overshoots further,
+  // to 3.1. 300px lands inside the "becomes 3" band. The width param is
+  // additive (test/fixtures/slider.html, #577) and load-bearing here -- the
+  // boundingBox() check right after open() guards against a broken or
+  // misspelled width param passing silently.
   test('tabbing onto a narrow slider does not round a fractional value or fire onChange (#577)', async ({ page }) => {
     await open(page, { min: 0, max: 10, from: 2.9, step: 0.1 }, { width: '300' });
+    // parseInt('abc', 10) is NaN, so a typo'd width would leave #wrap's CSS
+    // width unset -- the slider would then render at this fixture's
+    // default 600px, at which 2.9 never moves even under the mutation (see
+    // the width sweep above), so every assertion below would still pass
+    // without ever exercising the narrow-width path this test exists to
+    // cover. `.irs` is the exact element the plugin measures for all
+    // pixel<->value conversion (this.$cache.rs / coords.w_rs), so pinning
+    // its rendered width here ties the guard to the mechanism the rest of
+    // the test depends on.
+    const box = await page.locator('.irs').boundingBox();
+    expect(box.width).toBe(300);
     await tabToLine(page);
     await expect(page.locator('.irs-line')).toBeFocused();
     await page.waitForTimeout(400);
@@ -173,13 +199,19 @@ test.describe(`smoke (${LABEL})`, () => {
     expect(await eventTypes(page)).toEqual(['onStart']);
   });
 
-  // #557 in double mode: the pre-#742 pointerFocus() always targeted "from"
-  // ($handle = this.$cache.from whenever type !== "single"), so its
-  // synthesized click only ever snapped "from"; "to" was untouched. Pin
-  // exactly that asymmetric shape -- it documents the old default target,
-  // not a full double-mode #557 repro -- with a programmatic .focus() (the
-  // #557 report itself also names programmatic focus, not just Tab).
-  test('double: programmatic focus does not snap "from" or fire onChange (#557)', async ({ page }) => {
+  // #557 in double mode, via a programmatic .focus() rather than a real
+  // Tab -- the other half of the focus contract (arriving by .focus()
+  // alone must be exactly as inert as arriving by Tab), the same path the
+  // #742 focus tests above already use, and the cheapest way to exercise
+  // double mode here without stringing together a real Tab sequence. Pins
+  // that BOTH handles stay exactly as given and no onChange/onFinish
+  // fires. Mutation this catches: reinstating the 2.3.2-era focus handler,
+  // which always targeted "from" whenever type !== "single" ($handle =
+  // this.$cache.from) -- its synthesized click only ever snapped "from"
+  // (to 30 here), leaving "to" untouched at 67. That asymmetry is an
+  // artifact of the old handler's own hardcoded target, not a claim this
+  // test otherwise makes.
+  test('double: programmatic focus leaves both handles untouched and fires no onChange (#557)', async ({ page }) => {
     await open(page, { type: 'double', min: 0, max: 100, from: 33, to: 67, step: 10 });
     await page.locator('.irs-line').focus();
     await expect(page.locator('.irs-line')).toBeFocused();

--- a/test/fixtures/slider.html
+++ b/test/fixtures/slider.html
@@ -59,6 +59,12 @@
             // width/height at init time.
             document.getElementById('wrap').style.display = 'none';
         }
+        if (q.width) {
+            // #577 narrow-width coverage: a fractional value can round
+            // differently through the pixel<->value conversion at narrow
+            // slider widths than at this fixture's default 600px.
+            document.getElementById('wrap').style.width = parseInt(q.width, 10) + 'px';
+        }
         if (q.attrs) {
             // #535 data-* route coverage: apply attributes to the input
             // before init, the same server-markup channel config_from_data

--- a/test/fixtures/slider.html
+++ b/test/fixtures/slider.html
@@ -60,9 +60,14 @@
             document.getElementById('wrap').style.display = 'none';
         }
         if (q.width) {
-            // #577 narrow-width coverage: a fractional value can round
-            // differently through the pixel<->value conversion at narrow
-            // slider widths than at this fixture's default 600px.
+            // #577 narrow-width coverage: lets a test render the slider
+            // narrower than this fixture's default 600px. Needed because
+            // the pre-#742 focus handler read the handle's on-screen
+            // position through the pixel<->value conversion, and that
+            // introduced a small positional bias which grows as the
+            // slider narrows -- a fine-step value only crosses into the
+            // next step once the slider is narrow enough (see the #577
+            // test in smoke.spec.mjs for the measured widths).
             document.getElementById('wrap').style.width = parseInt(q.width, 10) + 'px';
         }
         if (q.attrs) {


### PR DESCRIPTION
This adds regression tests that pin a behavior already shipped in 2.4.0: focusing the slider, whether by pressing Tab or by a programmatic `.focus()` call, must never change its value or fire `onChange`.

Two issues reported the same underlying problem from different angles. In #557, tabbing from one slider to the next on a page with several sliders changed the value of the slider that gained focus, and `onChange` fired with a value the user never touched. In #577, a slider configured with `step: 0.1` and `from: 2.9`, on a layout narrow enough (roughly 325 pixels wide or less), turned into `3.0` the moment it was tabbed into. Both traced back to the same handler: before focus armed keyboard control, it also synthesized a click at the handle's current on-screen position. That synthesized click always fired `onChange` and `onFinish`, and it read the handle's position back through the same pixel-to-value conversion a real click uses, which introduced a small positional bias. That bias grows as the slider gets narrower. Whether the reported value actually moved depended on the step size relative to that bias: a value already off the step grid snapped straight onto the nearest step regardless of width, while a value already sitting on a fine step only crossed into the next one once the slider was narrow enough. This is the behavior removed in 2.4.0 by the change for #742 (pull request #839).

The new tests close a gap in the existing #742 coverage, which only checked callback counts on an already on-grid value and never checked the value itself. One tabs onto a slider holding an off-grid value and confirms it stays untouched. A second repeats that check on a slider narrowed to match the step and a width from the #577 report's stated range. A third confirms a programmatic focus on a two-handle slider leaves both handles untouched. Each test was verified against the pre-#742 behavior by temporarily restoring the old focus handler and confirming the exact failure it predicts: the off-grid value changing from 33 to 30, the double-handle value changing from 33;67 to 30;67, and the fractional value changing from 2.9 to 3 at a 300 pixel width. The temporary change was then reverted.

The test fixture also gained a small addition: an optional width parameter, so a test can render the slider at a specific narrow width instead of the default. This is additive only and does not change any existing test's behavior.

These tests cover a single slider. #557 was originally reported on a page with two sliders, and the multi-slider case adds a further wrinkle on top: which slider responds to a keyboard press when more than one is present. That is a separate, already known gap in test coverage, not something these tests attempt to cover. The focus behavior pinned here is the per-slider path, which is what actually changes a value or fires callbacks regardless of how many sliders are on the page.

No plugin code changes are included in this pull request.

Refs #557 #577
