### PR TITLE
Move the CI actions to their Node 24 majors (#863)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         node: [22, 24]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -33,8 +33,8 @@ jobs:
           - { id: '1.8.3', jquery: 'vendor/jquery-1.8.3.js', slim: '0', projects: '--project=chromium' }
           - { id: '4.0.0-slim', jquery: 'jquery-4.0.0', slim: '1', projects: '--project=chromium' }
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -42,7 +42,7 @@ jobs:
       - run: npm run build
       - id: pw
         run: echo "version=$(node -e 'console.log(require("@playwright/test/package.json").version)')" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v4
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
@@ -52,7 +52,7 @@ jobs:
           IRS_JQUERY: ${{ matrix.jquery }}
           IRS_SLIM: ${{ matrix.slim }}
           IRS_MIN: ${{ matrix.min || '0' }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: playwright-report-${{ matrix.id }}
@@ -63,10 +63,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/jquery-matrix.yml
+++ b/.github/workflows/jquery-matrix.yml
@@ -33,8 +33,8 @@ jobs:
           - { id: '4.0.0', jquery: 'jquery-4.0.0', slim: '0' }
           - { id: '4.0.0-slim', jquery: 'jquery-4.0.0', slim: '1' }
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -42,7 +42,7 @@ jobs:
       - run: npm run build
       - id: pw
         run: echo "version=$(node -e 'console.log(require("@playwright/test/package.json").version)')" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v4
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
@@ -52,7 +52,7 @@ jobs:
           IRS_JQUERY: ${{ matrix.jquery }}
           IRS_SLIM: ${{ matrix.slim }}
           IRS_MIN: ${{ matrix.min || '0' }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: playwright-report-${{ matrix.id }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,10 +61,14 @@ jobs:
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
+      # package-manager-cache is off explicitly: setup-node v5+ turns its
+      # npm cache on by itself once package.json gains a packageManager
+      # field, and a poisoned cache must never sit next to the OIDC token.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       # Trusted publishing needs npm >= 11.5.1; the node-version above
       # bundles an older npm, so upgrade it before anything else runs.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,11 +57,11 @@ jobs:
       # Tag-qualified: an unqualified ref resolves branch-before-tag, so
       # a branch that happened to share a release's name would silently
       # get checked out (and published) instead of the tag.
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@
 # npm reject the publish). Until that is configured, `npm publish`
 # below will fail with an auth error.
 #
-# actions/checkout and actions/setup-node are pinned to a commit SHA
-# (not just the v4 tag ci.yml/jquery-matrix.yml use) because this job
-# carries id-token: write, which can mint short-lived OIDC credentials -
-# only the publish path needs that extra supply-chain hardening.
+# Every workflow pins its actions to a commit SHA with the version in a
+# trailing comment (since #863). It matters most here: this job carries
+# id-token: write, which can mint short-lived OIDC credentials, so a moved
+# tag must never be able to change what runs on the publish path.
 #
 # Normal release: pushing a release tag (bare number, e.g. "2.3.2") runs
 # this automatically. To publish a tag that was already pushed (for

--- a/test/browser/smoke.spec.mjs
+++ b/test/browser/smoke.spec.mjs
@@ -5,9 +5,7 @@ test.describe(`smoke (${LABEL})`, () => {
   test('init renders, writes the input and fires onStart once', async ({ page }) => {
     await open(page, { min: 0, max: 100, from: 30 });
     await expect(page.locator('.irs--flat')).toHaveCount(1);
-    // Temporary probe for #863: deliberately wrong expected value, to
-    // exercise the report upload on a failing browser run.
-    await expect(input(page)).toHaveValue('31');
+    await expect(input(page)).toHaveValue('30');
     const ev = await events(page);
     expect(ev.map((e) => e.type)).toEqual(['onStart']);
     expect(ev[0]).toMatchObject({ from: 30, min: 0, max: 100 });

--- a/test/browser/smoke.spec.mjs
+++ b/test/browser/smoke.spec.mjs
@@ -5,7 +5,9 @@ test.describe(`smoke (${LABEL})`, () => {
   test('init renders, writes the input and fires onStart once', async ({ page }) => {
     await open(page, { min: 0, max: 100, from: 30 });
     await expect(page.locator('.irs--flat')).toHaveCount(1);
-    await expect(input(page)).toHaveValue('30');
+    // Temporary probe for #863: deliberately wrong expected value, to
+    // exercise the report upload on a failing browser run.
+    await expect(input(page)).toHaveValue('31');
     const ev = await events(page);
     expect(ev.map((e) => e.type)).toEqual(['onStart']);
     expect(ev[0]).toMatchObject({ from: 30, min: 0, max: 100 });


### PR DESCRIPTION
Every workflow run has been carrying a warning from GitHub that the checkout and setup-node steps target Node.js 20, a runtime being retired on the hosted runners and forced onto Node.js 24 in the meantime. The cache and artifact-upload actions sit on the same Node 20 runtime at their old tags, although the annotation does not name them. This change moves all four actions to their current majors, which run on Node 24 natively, and pins each one by commit hash with the version in a comment, the way the publish workflow already did, so a moved tag can never change what runs.

Nothing about the tests or the build changes. Contributors see the same jobs, the same steps and the same results; only the runtime the workflow steps execute under is different. None of the skipped majors renamed or changed the default of an input these workflows use.

The evidence is in this pull request's own runs: no Node 20 annotation on any job, the browser cache reporting a normal hit or save, and a Playwright report uploaded by a run with one deliberately failing test, which confirms the artifact step under the new version. That failing test was reverted in the next commit and is not part of the change.

Closes #863
