### PR TITLE
Add step_from_min to count the step scale from min (#869)

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -2265,16 +2265,20 @@
                 return this.options.max;
             }
 
-            // #869: with step_from_min the steps are counted from min instead
-            // of from zero, so the values are min, min + step, min + 2 * step,
-            // ... plus max. The rounding at the end only cleans binary float
-            // noise off a lattice point the arithmetic has already placed,
-            // which is why it takes the widest decimal count of step, min and
-            // max instead of the step's alone. No negative-min shift is needed
-            // here: the distance is measured from min, wherever min sits.
-            // validate() guarantees step > 0. The branch below counts from
-            // zero -- an integer step therefore lands on whole numbers, and a
-            // fractional min is dropped -- and stays byte-identical while
+            // #869: with step_from_min every value is min plus a whole number
+            // of steps (min, min + step, min + 2 * step, ... plus max). The
+            // rounding at the end only cleans binary float noise off a scale
+            // point the arithmetic has already placed, which is why it takes
+            // the widest decimal count of step, min and max instead of the
+            // step's alone. No negative-min shift is needed here: the distance
+            // is measured from min, wherever min sits. validate() guarantees
+            // step > 0. Limits and intervals are clamped in percent and then
+            // land on the nearest scale point like any other value, so a
+            // from_min/from_max/to_min/to_max or min_interval that is not on
+            // the scale is crossed by up to half a step (the branch below does
+            // the same for integer steps). The branch below rounds to the
+            // step's decimals, so an integer step lands on whole numbers and a
+            // fractional min is dropped; it stays byte-identical while
             // step_from_min is off, which is the default.
             if (this.options.step_from_min) {
                 var step_offset = (this.options.max - this.options.min) / 100 * percent,
@@ -2296,7 +2300,6 @@
 
                 return step_value;
             }
-
 
             if (min_decimals) {
                 min_length = min_decimals;

--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -2272,14 +2272,18 @@
             // the widest decimal count of step, min and max instead of the
             // step's alone. No negative-min shift is needed here: the distance
             // is measured from min, wherever min sits. validate() guarantees
-            // step > 0. Limits and intervals are clamped in percent and then
-            // land on the nearest scale point like any other value, so a
-            // from_min/from_max/to_min/to_max or min_interval that is not on
-            // the scale is crossed by up to half a step (the branch below does
-            // the same for integer steps). The branch below rounds to the
-            // step's decimals, so an integer step lands on whole numbers and a
-            // fractional min is dropped; it stays byte-identical while
-            // step_from_min is off, which is the default.
+            // step > 0. The clamp helpers (checkDiapason, checkMinInterval,
+            // checkMaxInterval) compare values exactly but hand the limit back
+            // as a percent, and the next convertToValue() call rounds that
+            // percent onto the nearest scale point, so a from_min/from_max/
+            // to_min/to_max, min_interval or max_interval that is not on the
+            // scale is crossed by up to half a step (the branch below does the
+            // same for integer steps with a min at or above zero). The branch
+            // below rounds to the step's decimals, so with a min at or above
+            // zero an integer step lands on whole numbers and the min's
+            // fraction is dropped (a negative min is shifted first, see #760
+            // below); it stays byte-identical while step_from_min is off,
+            // which is the default.
             if (this.options.step_from_min) {
                 var step_offset = (this.options.max - this.options.min) / 100 * percent,
                     step_count = Math.round(step_offset / this.options.step),

--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -307,6 +307,7 @@
             from: null,
             to: null,
             step: 1,
+            step_from_min: false,
 
             min_interval: 0,
             max_interval: 0,
@@ -387,6 +388,7 @@
             from: $inp.data("from"),
             to: $inp.data("to"),
             step: $inp.data("step"),
+            step_from_min: $inp.data("stepFromMin"),
 
             min_interval: $inp.data("minInterval"),
             max_interval: $inp.data("maxInterval"),
@@ -2261,6 +2263,38 @@
             }
             if (percent === 100) {
                 return this.options.max;
+            }
+
+            // #869: with step_from_min the steps are counted from min instead
+            // of from zero, so the values are min, min + step, min + 2 * step,
+            // ... plus max. The rounding at the end only cleans binary float
+            // noise off a lattice point the arithmetic has already placed,
+            // which is why it takes the widest decimal count of step, min and
+            // max instead of the step's alone. No negative-min shift is needed
+            // here: the distance is measured from min, wherever min sits.
+            // validate() guarantees step > 0. The branch below counts from
+            // zero -- an integer step therefore lands on whole numbers, and a
+            // fractional min is dropped -- and stays byte-identical while
+            // step_from_min is off, which is the default.
+            if (this.options.step_from_min) {
+                var step_offset = (this.options.max - this.options.min) / 100 * percent,
+                    step_count = Math.round(step_offset / this.options.step),
+                    step_value = this.options.min + (step_count * this.options.step),
+                    step_precision = Math.max(this.getDecimalPlaces(this.options.step), min_decimals, max_decimals);
+
+                if (step_precision) {
+                    step_value = +step_value.toFixed(step_precision);
+                } else {
+                    step_value = this.toFixed(step_value);
+                }
+
+                if (step_value < this.options.min) {
+                    step_value = this.options.min;
+                } else if (step_value > this.options.max) {
+                    step_value = this.options.max;
+                }
+
+                return step_value;
             }
 
 

--- a/readme.md
+++ b/readme.md
@@ -127,7 +127,7 @@ Or use `data-*` attributes on the input:
 | `max` | `data-max` | `100` | number | Maximum value |
 | `from` | `data-from` | `min` | number | Start position for left handle (or single handle) |
 | `to` | `data-to` | `max` | number | Start position for right handle |
-| `step` | `data-step` | `1` | number | Step size. Always > 0. Can be fractional. Values are rounded to the decimals of `step`, so an integer step gives whole numbers even when `min` is fractional; see `step_from_min` |
+| `step` | `data-step` | `1` | number | Step size. Always > 0. Can be fractional. Values are rounded to the decimals of `step`; with `min: 0.5, step: 1` that gives 0.5, 2, 3 ... See `step_from_min` to keep the scale on `min` |
 | `step_from_min` | `data-step-from-min` | `false` | boolean | Make every value `min` plus a whole number of steps: with `min: 0.5, step: 1` the values are 0.5, 1.5, 2.5 ... instead of 0.5, 2, 3 ... Grid labels follow the same scale. Put an initial `from`/`to`, the handle limits and `min_interval`/`max_interval` on that scale too; a value off it is moved to the nearest point |
 | `min_interval` | `data-min-interval` | `-` | number | Minimum range between handles. Double type only |
 | `max_interval` | `data-max-interval` | `-` | number | Maximum range between handles. Double type only |

--- a/readme.md
+++ b/readme.md
@@ -127,7 +127,8 @@ Or use `data-*` attributes on the input:
 | `max` | `data-max` | `100` | number | Maximum value |
 | `from` | `data-from` | `min` | number | Start position for left handle (or single handle) |
 | `to` | `data-to` | `max` | number | Start position for right handle |
-| `step` | `data-step` | `1` | number | Step size. Always > 0. Can be fractional |
+| `step` | `data-step` | `1` | number | Step size. Always > 0. Can be fractional. Steps are counted from zero unless `step_from_min` is set |
+| `step_from_min` | `data-step-from-min` | `false` | boolean | Count the steps from `min` instead of from zero: with `min: 0.5, step: 1` the values are 0.5, 1.5, 2.5 instead of 1, 2, 3. Grid labels follow the same scale |
 | `min_interval` | `data-min-interval` | `-` | number | Minimum range between handles. Double type only |
 | `max_interval` | `data-max-interval` | `-` | number | Maximum range between handles. Double type only |
 | `drag_interval` | `data-drag-interval` | `false` | boolean | Allow dragging the whole range. Double type only |

--- a/readme.md
+++ b/readme.md
@@ -127,8 +127,8 @@ Or use `data-*` attributes on the input:
 | `max` | `data-max` | `100` | number | Maximum value |
 | `from` | `data-from` | `min` | number | Start position for left handle (or single handle) |
 | `to` | `data-to` | `max` | number | Start position for right handle |
-| `step` | `data-step` | `1` | number | Step size. Always > 0. Can be fractional. Steps are counted from zero unless `step_from_min` is set |
-| `step_from_min` | `data-step-from-min` | `false` | boolean | Count the steps from `min` instead of from zero: with `min: 0.5, step: 1` the values are 0.5, 1.5, 2.5 instead of 1, 2, 3. Grid labels follow the same scale |
+| `step` | `data-step` | `1` | number | Step size. Always > 0. Can be fractional. Values are rounded to the decimals of `step`, so an integer step gives whole numbers even when `min` is fractional; see `step_from_min` |
+| `step_from_min` | `data-step-from-min` | `false` | boolean | Make every value `min` plus a whole number of steps: with `min: 0.5, step: 1` the values are 0.5, 1.5, 2.5 ... instead of 0.5, 2, 3 ... Grid labels follow the same scale. Put an initial `from`/`to`, the handle limits and `min_interval`/`max_interval` on that scale too; a value off it is moved to the nearest point |
 | `min_interval` | `data-min-interval` | `-` | number | Minimum range between handles. Double type only |
 | `max_interval` | `data-max-interval` | `-` | number | Maximum range between handles. Double type only |
 | `drag_interval` | `data-drag-interval` | `false` | boolean | Allow dragging the whole range. Double type only |

--- a/test/browser/step-from-min.spec.mjs
+++ b/test/browser/step-from-min.spec.mjs
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+import { open, drag, eventTypes, input, LABEL } from './helpers.mjs';
+
+// Real-browser coverage for issue #869: the new `step_from_min` option
+// (default false) counts the step scale from `min` instead of from zero, so
+// {min: 0.5, max: 10.5, step: 1} runs 0.5, 1.5, 2.5 rather than snapping to
+// whole numbers. The jsdom suite (zero layout, see test/unit/helpers.mjs)
+// covers convertToValue() and the grid text directly; these tests drive the
+// same option through real layout, a real drag and real key presses, and
+// assert only what the page shows: the handle bubble, the input's value and
+// the grid labels.
+
+test.describe(`step_from_min coverage (${LABEL})`, () => {
+  // B1. Against 2.4.2 this renders "3": calc()'s "base" case round-trips the
+  // initial `from` through convertToValue(), which rounds to the step's
+  // decimals and drops min's half. One-line bug this catches: no
+  // `step_from_min` branch in convertToValue().
+  test('an initial from of 2.5 stays 2.5 in the bubble and the input (#869)', async ({ page }) => {
+    await open(page, { type: 'single', min: 0.5, max: 10.5, step: 1, from: 2.5, step_from_min: true });
+
+    await expect(page.locator('.irs-single')).toHaveText('2.5');
+    await expect(input(page)).toHaveValue('2.5');
+
+    await page.evaluate(() => window.__irs.slider.update({}));
+
+    await expect(page.locator('.irs-single')).toHaveText('2.5');
+    await expect(input(page)).toHaveValue('2.5');
+  });
+
+  // B2. Same config through a real pointer drag, so the option is proven on
+  // the interaction path and not only on the initial render. Against 2.4.2
+  // the handle lands on a whole number. One-line bug this catches: reading
+  // the option only in calc()'s "base" case.
+  test('a drag lands on the min-anchored scale, not on a whole number (#869)', async ({ page }) => {
+    await open(page, { type: 'single', min: 0.5, max: 10.5, step: 1, from: 2.5, step_from_min: true });
+
+    await drag(page, '.irs-handle.single', 0.3);
+    await expect.poll(() => eventTypes(page)).toContain('onFinish');
+
+    const label = await page.locator('.irs-single').textContent();
+    // Moved guard: the starting value 2.5 also matches the pattern below, so
+    // without this a drag that silently moved nothing would still pass.
+    expect(label).not.toBe('2.5');
+    expect(label).toMatch(/^\d+\.5$/);
+    await expect(input(page)).toHaveValue(label);
+  });
+
+  // B3. Against 2.4.2 the three presses read 1, 2, 3: the from-zero rounding
+  // discards min's 0.01. One-line bug this catches: the lattice anchored at
+  // zero rather than at min.
+  test('arrow keys walk a 0.01 minimum as 1.01, 2.01, 3.01 (#869)', async ({ page }) => {
+    await open(page, { type: 'single', min: 0.01, max: 10, step: 1, step_from_min: true });
+
+    await expect(input(page)).toHaveValue('0.01');
+    await page.locator('.irs-line').focus();
+    await expect(page.locator('.irs-line')).toBeFocused();
+    // Outlast the 300 ms idle render poll so a callback pending from the
+    // focus cannot coalesce with the first key press.
+    await page.waitForTimeout(400);
+
+    for (const value of ['1.01', '2.01', '3.01']) {
+      await page.keyboard.press('ArrowRight');
+      await expect(input(page)).toHaveValue(value);
+    }
+  });
+
+  // B4. Grid ticks label themselves through the same convertToValue(), so the
+  // option has to reach them too. Against 2.4.2 the labels read "2.6" and
+  // "7.4" (rounded to the step's one decimal) where this config's own scale
+  // has 2.75 and 7.25. One-line bug this catches: reading the option only on
+  // the handle path.
+  test('grid labels follow the min-anchored scale (#869)', async ({ page }) => {
+    await open(page, { type: 'single', min: 0.25, max: 9.75, step: 0.5, grid: true, step_from_min: true });
+
+    const texts = await page.locator('.irs-grid-text').allTextContents();
+    expect(texts).toEqual(['0.25', '2.75', '5.25', '7.25', '9.75']);
+  });
+
+  // B5. The default-off twin of B1: characterization of today's behavior,
+  // green before and after. Mutation with catching power: make the new branch
+  // in convertToValue() unconditional (drop the `this.options.step_from_min`
+  // test) -- the bubble would read "2.5" here instead of "3".
+  test('without the option an initial from of 2.5 still renders as 3 (#869)', async ({ page }) => {
+    await open(page, { type: 'single', min: 0.5, max: 10.5, step: 1, from: 2.5 });
+
+    await expect(page.locator('.irs-single')).toHaveText('3');
+    await expect(input(page)).toHaveValue('3');
+  });
+
+  // B6. The data-attribute route, the channel server-rendered markup uses.
+  // One-line bug this catches: no `step_from_min: $inp.data("stepFromMin")`
+  // line in config_from_data -- the attribute is ignored and the bubble falls
+  // back to "3".
+  test('data-step-from-min="true" has the same effect as the JS option (#869)', async ({ page }) => {
+    await open(
+      page,
+      { type: 'single', min: 0.5, max: 10.5, step: 1, from: 2.5 },
+      { attrs: JSON.stringify({ 'data-step-from-min': 'true' }) }
+    );
+
+    await expect(page.locator('.irs-single')).toHaveText('2.5');
+    await expect(input(page)).toHaveValue('2.5');
+  });
+});

--- a/test/unit/step-from-min.test.mjs
+++ b/test/unit/step-from-min.test.mjs
@@ -4,8 +4,8 @@ import { createSlider } from './helpers.mjs';
 
 // #869: `step_from_min` (new, default false) counts the step scale from
 // `min` instead of from zero. Off, convertToValue() rounds its result to the
-// decimals of `step`, so an integer step always lands on whole numbers and a
-// fractional `min` is dropped: {min: 0.5, max: 10.5, step: 1} snaps to 2, 3,
+// decimals of `step`, so with a min at or above zero an integer step lands on
+// whole numbers and the min's fraction is dropped: {min: 0.5, max: 10.5, step: 1} snaps to 2, 3,
 // 4 rather than to its own scale 1.5, 2.5, 3.5. On, the value is min plus a
 // whole number of steps, so the scale starts at min and the final rounding
 // only cleans binary float noise.
@@ -259,18 +259,22 @@ test('step_from_min defaults to false (#869)', (t) => {
 });
 
 // T12. Known limit of the scale, pinned on purpose so a change to it is a
-// deliberate one. Limits are clamped in percent and the clamped percent then
-// lands on the nearest scale point like any other value, so a from_max that
-// is not on the scale is crossed by half a step: from_max 5 on the 0.5, 1.5,
-// ... scale becomes 5.5 (round half up). The default path does the same for
-// integer steps (from_min 2.4 lands on 2). Reds if the clamp helpers learn
-// to snap inward (ceil for a lower limit, floor for an upper one), which is
-// the fix a follow-up issue tracks; the readme row therefore asks users to
-// put limits on the scale.
+// deliberate one. checkDiapason() compares the value against from_max exactly
+// but hands the limit back as a percent, and the convertToValue() read-back
+// in drawHandles() rounds that percent onto the nearest scale point, so a
+// from_max that is not on the scale is crossed by half a step: from_max 5 on
+// the 0.5, 1.5, ... scale becomes 5.5 (round half up). calc()'s base case
+// runs checkDiapason() for the initial from: 8, so primeSingle() drives the
+// real path (a direct convertToValue() call would never reach the clamp).
+// The default path does the same for integer steps with a min at or above
+// zero (from_min 2.4 lands on 2). Reds with 4.5 if checkDiapason() learns to
+// snap an upper limit down onto the scale, the fix a follow-up issue tracks;
+// the readme row therefore asks users to put limits on the scale.
 test('a from_max off the scale is crossed by half a step with step_from_min on, pinned (#869)', (t) => {
   const { slider } = createSlider(t, '<input>', {
-    min: 0.5, max: 10.5, step: 1, from_max: 5, step_from_min: true
+    min: 0.5, max: 10.5, step: 1, from: 8, from_max: 5, step_from_min: true
   });
+  primeSingle(slider);
 
-  assert.equal(slider.convertToValue(slider.convertToPercent(5)), 5.5);
+  assert.equal(slider.result.from, 5.5);
 });

--- a/test/unit/step-from-min.test.mjs
+++ b/test/unit/step-from-min.test.mjs
@@ -257,3 +257,20 @@ test('step_from_min defaults to false (#869)', (t) => {
 
   assert.equal(slider.options.step_from_min, false);
 });
+
+// T12. Known limit of the scale, pinned on purpose so a change to it is a
+// deliberate one. Limits are clamped in percent and the clamped percent then
+// lands on the nearest scale point like any other value, so a from_max that
+// is not on the scale is crossed by half a step: from_max 5 on the 0.5, 1.5,
+// ... scale becomes 5.5 (round half up). The default path does the same for
+// integer steps (from_min 2.4 lands on 2). Reds if the clamp helpers learn
+// to snap inward (ceil for a lower limit, floor for an upper one), which is
+// the fix a follow-up issue tracks; the readme row therefore asks users to
+// put limits on the scale.
+test('a from_max off the scale is crossed by half a step with step_from_min on, pinned (#869)', (t) => {
+  const { slider } = createSlider(t, '<input>', {
+    min: 0.5, max: 10.5, step: 1, from_max: 5, step_from_min: true
+  });
+
+  assert.equal(slider.convertToValue(slider.convertToPercent(5)), 5.5);
+});

--- a/test/unit/step-from-min.test.mjs
+++ b/test/unit/step-from-min.test.mjs
@@ -1,0 +1,259 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSlider } from './helpers.mjs';
+
+// #869: `step_from_min` (new, default false) counts the step scale from
+// `min` instead of from zero. Off, convertToValue() rounds its result to the
+// decimals of `step`, so an integer step always lands on whole numbers and a
+// fractional `min` is dropped: {min: 0.5, max: 10.5, step: 1} snaps to 2, 3,
+// 4 rather than to its own scale 1.5, 2.5, 3.5. On, the value is min plus a
+// whole number of steps, so the scale starts at min and the final rounding
+// only cleans binary float noise.
+//
+// Turning this on by default would move values for anyone using a config
+// like {min: 0.01, step: 1} to keep zero out of the range (1, 2, 3 would
+// become 1.01, 2.01, 3.01), which is why it is opt-in. The tests below pin
+// both sides: the new scale when the option is on, and today's values when
+// it is off.
+//
+// jsdom has no layout (see helpers.mjs), so convertToValue() and appendGrid()
+// are exercised directly; the two tests that need a real handle position stub
+// the geometry the way the drag tests do. The user-visible surface (bubbles,
+// input value, grid text, keyboard) is covered in
+// test/browser/step-from-min.spec.mjs.
+
+/**
+ * jsdom has no real layout: stub $cache.rs.outerWidth()/.offset() to a fixed
+ * 600px-wide slider and the single handle to 16px, mirroring the browser
+ * fixture's flat-skin geometry (the same primeSingle() as
+ * test/unit/drag-end-callbacks.test.mjs). The one drawHandles() pass settles
+ * the resize branch, which is also what round-trips the initial `from`
+ * through calc()'s "base" case and convertToValue().
+ */
+function primeSingle(slider) {
+  slider.$cache.rs.outerWidth = function () { return 600; };
+  slider.$cache.rs.offset = function () { return { left: 0 }; };
+  slider.$cache.s_single.outerWidth = function () { return 16; };
+  slider.drawHandles();
+}
+
+function gridTexts(slider) {
+  return slider.$cache.grid.find('.irs-grid-text').map(function () { return this.textContent; }).get();
+}
+
+// T1. One-line bug this catches: no `step_from_min` branch in
+// convertToValue() at all (the option is read but ignored) -- the existing
+// integer-step path rounds to whole numbers and returns 2 and 3.
+test('step_from_min puts {min: 0.5, max: 10.5, step: 1} on its own 0.5, 1.5, 2.5 scale (#869)', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: 0.5, max: 10.5, step: 1, step_from_min: true });
+
+  assert.equal(slider.convertToValue(10), 1.5);
+  assert.equal(slider.convertToValue(20), 2.5);
+});
+
+// T2. One-line bug this catches: rounding the result to the step's decimals
+// instead of snapping to the min-anchored lattice -- 0.75 and 1.25 would come
+// back as 0.8 and 1.3 (the step has one decimal, the scale needs two).
+test('step_from_min keeps a min with more decimals than the step, {0.25, 9.75, 0.5} (#869)', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: 0.25, max: 9.75, step: 0.5, step_from_min: true });
+
+  const p1 = slider.convertToPercent(0.75);
+  assert.equal(slider.convertToValue(p1), 0.75, `convertToValue(${p1}) must be the first point above min`);
+
+  const p2 = slider.convertToPercent(1.25);
+  assert.equal(slider.convertToValue(p2), 1.25, `convertToValue(${p2}) must be the second point above min`);
+});
+
+// T3. One-line bug this catches: anchoring the lattice at zero rather than at
+// min -- the three presses would read 1, 2, 3 instead of 1.01, 2.01, 3.01.
+// Drives the real keyboard path (pointerFocus + moveByKey), so it also proves
+// the option survives calc()'s step snapping, not just a direct call.
+test('step_from_min: arrow keys walk {min: 0.01, max: 10, step: 1} as 1.01, 2.01, 3.01 (#869)', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: 0.01, max: 10, step: 1, step_from_min: true });
+  primeSingle(slider);
+
+  assert.equal(slider.result.from, 0.01, 'the handle starts at min');
+
+  slider.pointerFocus({});
+  assert.equal(slider.target, 'single', 'a fresh focus must arm the single handle');
+
+  const seen = [];
+  for (let i = 0; i < 3; i++) {
+    slider.moveByKey(true);
+    seen.push(slider.result.from);
+  }
+  assert.deepEqual(seen, [1.01, 2.01, 3.01]);
+});
+
+// T4. One-line bug this catches: applying the existing negative-min shift
+// inside the new branch (or rounding to the step's one decimal) -- both give
+// the 2.4.2 values -39.9 and -39.8, half a step off this config's own scale.
+test('step_from_min keeps a negative min with more decimals than the step, {-39.95, 111, 0.1} (#869)', (t) => {
+  const { slider } = createSlider(t, '<input>', { type: 'double', min: -39.95, max: 111, step: 0.1, step_from_min: true });
+
+  const p1 = slider.convertToPercent(-39.85);
+  assert.equal(slider.convertToValue(p1), -39.85, `convertToValue(${p1}) must be min + one step`);
+
+  const p2 = slider.convertToPercent(-39.75);
+  assert.equal(slider.convertToValue(p2), -39.75, `convertToValue(${p2}) must be min + two steps`);
+});
+
+// T5. One-line bug this catches: the same rounding-to-step-decimals defect at
+// a two-decimal negative min with a half step -- the three step positions
+// would read -198, -197.5, -197 instead of staying on min's own scale.
+test('step_from_min walks {-198.53, 100, 0.5} from min in half steps (#869)', (t) => {
+  const { slider } = createSlider(t, '<input>', { type: 'double', min: -198.53, max: 100, step: 0.5, step_from_min: true });
+
+  const snapped = (k) => slider.calcWithStep(slider.coords.p_step * k);
+  const seen = [1, 2, 3].map((k) => slider.convertToValue(snapped(k)));
+
+  assert.deepEqual(seen, [-198.03, -197.53, -197.03]);
+});
+
+// T6. Regression guard for #760, green before and after this feature: with
+// the option on, {min: -39.9, max: 111, step: 1} must still produce the clean
+// lattice points and grid labels #760 fixed. The mutation with catching power
+// here: size the new branch's final rounding from the step's decimals alone
+// (`precision = this.getDecimalPlaces(this.options.step)`) -- the binary float
+// noise comes straight back, 0.10000000000000142 / -15.899999999999999 and a
+// "-1.9000000000000057" grid label.
+test('step_from_min leaves the #760 config free of float noise, values and grid (#869)', (t) => {
+  const { slider } = createSlider(t, '<input>', {
+    type: 'double', min: -39.9, max: 111, step: 1, step_from_min: true, grid: true, grid_num: 4
+  });
+
+  const nearZero = slider.convertToPercent(0);
+  assert.equal(slider.convertToValue(nearZero), 0.1);
+
+  const near16 = slider.convertToPercent(-16);
+  assert.equal(slider.convertToValue(near16), -15.9);
+
+  assert.deepEqual(gridTexts(slider), ['-39.9', '-1.9', '35.1', '73.1', '111']);
+});
+
+// T7. Controls: for a config whose scale already starts on a step boundary
+// the option must change nothing at all. Compared against a second slider
+// built with the option off, so any drift shows up as a difference rather
+// than needing a hand-maintained expectation, and against the literal values
+// so a defect shared by both paths cannot hide. One-line bug this catches: an
+// off-by-one in the step count (`Math.round(offset / step) + 1`) -- every
+// value below moves one step up.
+test('step_from_min is a no-op for configs whose scale already starts on a step (#869)', (t) => {
+  const cases = [
+    { config: { min: 1.5, max: 2.5, step: 0.25 }, percents: [0, 25, 50, 75, 100], expected: [1.5, 1.75, 2, 2.25, 2.5] },
+    { config: { min: 0, max: 100, step: 1 }, percents: [0, 25, 50, 75, 100], expected: [0, 25, 50, 75, 100] },
+    { config: { min: 10, max: 20, step: 0.5 }, percents: [5, 25, 50, 75, 100], expected: [10.5, 12.5, 15, 17.5, 20] },
+    { config: { min: 0, max: 1, step: 1e-8 }, percents: [12, 33, 50], expected: [0.12, 0.33, 0.5] }
+  ];
+
+  for (const { config, percents, expected } of cases) {
+    const on = createSlider(t, '<input>', { ...config, step_from_min: true }).slider;
+    const off = createSlider(t, '<input>', config).slider;
+    const label = JSON.stringify(config);
+
+    assert.deepEqual(percents.map((p) => on.convertToValue(p)), expected, `step_from_min on, ${label}`);
+    assert.deepEqual(percents.map((p) => off.convertToValue(p)), expected, `step_from_min off, ${label}`);
+  }
+});
+
+// T8. One-line bug this catches: reading the option only on the handle path,
+// so grid ticks keep the from-zero rounding -- the labels would read 2.6 and
+// 7.4 where this config's scale has 2.75 and 7.25.
+test('step_from_min moves the grid labels onto the same scale, {0.25, 9.75, 0.5} (#869)', (t) => {
+  const { slider } = createSlider(t, '<input>', {
+    min: 0.25, max: 9.75, step: 0.5, step_from_min: true, grid: true
+  });
+
+  assert.deepEqual(gridTexts(slider), ['0.25', '2.75', '5.25', '7.25', '9.75']);
+});
+
+// T8b, grid_snap: every tick is one step apart, so the whole scale is visible
+// at once. Same one-line bug as T8.
+test('step_from_min with grid_snap labels every step from min, {0.25, 9.75, 0.5} (#869)', (t) => {
+  const { slider } = createSlider(t, '<input>', {
+    min: 0.25, max: 9.75, step: 0.5, step_from_min: true, grid: true, grid_snap: true
+  });
+
+  const expected = [];
+  for (let i = 0; i <= 19; i++) {
+    expected.push(String(0.25 + i * 0.5));
+  }
+  assert.deepEqual(gridTexts(slider), expected);
+});
+
+// T9. One-line bug this catches: reading the option only inside the keyboard
+// or drag paths -- calc()'s "base" case round-trips the initial `from` through
+// convertToValue() on the first render, so an off-scale initial value would be
+// rewritten to 3 at first paint even though nobody touched the handle.
+test('step_from_min keeps an initial from: 2.5 at 2.5, at first render and after update() (#869)', (t) => {
+  const { slider } = createSlider(t, '<input>', {
+    min: 0.5, max: 10.5, step: 1, from: 2.5, step_from_min: true
+  });
+  primeSingle(slider);
+
+  assert.equal(slider.result.from, 2.5, 'first render must keep the initial value');
+
+  slider.update({});
+  primeSingle(slider);
+
+  assert.equal(slider.result.from, 2.5, 'update() must keep the initial value');
+});
+
+// T9b, the default-off twin: characterization of today's behavior, green
+// before and after. Mutation with catching power: make the new branch
+// unconditional (drop the `this.options.step_from_min` test) -- from would
+// stay 2.5 here instead of being rewritten to 3.
+test('without step_from_min an initial from: 2.5 still renders as 3 (#869)', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: 0.5, max: 10.5, step: 1, from: 2.5 });
+  primeSingle(slider);
+
+  assert.equal(slider.result.from, 3);
+});
+
+// T10. Default-off twins for T1, T2 and T4: characterization of the 2.4.2
+// values, green before and after. Same mutation as T9b: making the new branch
+// unconditional turns every one of these into its min-anchored counterpart
+// (1.5 / 2.5, 0.75 / 1.25, -39.85 / -39.75).
+test('with step_from_min off every scale stays exactly where 2.4.2 put it (#869)', (t) => {
+  const a = createSlider(t, '<input>', { min: 0.5, max: 10.5, step: 1 }).slider;
+  assert.equal(a.convertToValue(10), 2);
+  assert.equal(a.convertToValue(20), 3);
+
+  const b = createSlider(t, '<input>', { min: 0.25, max: 9.75, step: 0.5 }).slider;
+  assert.equal(b.convertToValue(b.convertToPercent(0.75)), 0.8);
+  assert.equal(b.convertToValue(b.convertToPercent(1.25)), 1.3);
+
+  const c = createSlider(t, '<input>', { type: 'double', min: -39.95, max: 111, step: 0.1 }).slider;
+  assert.equal(c.convertToValue(c.convertToPercent(-39.85)), -39.9);
+  assert.equal(c.convertToValue(c.convertToPercent(-39.75)), -39.8);
+});
+
+// T11. One-line bug this catches: no `step_from_min: $inp.data("stepFromMin")`
+// line in config_from_data -- the attribute is silently ignored and the JS
+// option survives. The strict equal also pins jQuery's data() string->boolean
+// coercion: a stray .attr() read would leave the string "true".
+test('data-step-from-min="true" turns the option on (#869)', (t) => {
+  const { slider } = createSlider(t, '<input data-step-from-min="true">', { min: 0.5, max: 10.5, step: 1 });
+
+  assert.equal(slider.options.step_from_min, true);
+  assert.equal(slider.convertToValue(10), 1.5);
+});
+
+// T11b, the other direction, so a wiring that only honours a truthy attribute
+// (an `||` instead of the `undefined`/"" strip config_from_data already uses)
+// is caught too.
+test('data-step-from-min="false" overrides a JS step_from_min: true (#869)', (t) => {
+  const { slider } = createSlider(t, '<input data-step-from-min="false">', {
+    min: 0.5, max: 10.5, step: 1, step_from_min: true
+  });
+
+  assert.equal(slider.options.step_from_min, false);
+  assert.equal(slider.convertToValue(10), 2);
+});
+
+// The default itself, so a change of mind about opting in shows up here.
+test('step_from_min defaults to false (#869)', (t) => {
+  const { slider } = createSlider(t, '<input>', { min: 0, max: 100 });
+
+  assert.equal(slider.options.step_from_min, false);
+});


### PR DESCRIPTION
Slider values have always been rounded to the number of decimals in `step`. With an integer step and a minimum at or above zero that means whole numbers, so the fraction in `min` is dropped from the scale. A slider configured as `{min: 0.5, max: 10.5, step: 1}` starts at 0.5 and then jumps to 2, 3, 4 rather than 1.5, 2.5, 3.5, and an initial `from: 2.5` is rewritten to 3 on the first paint. The same rounding reaches the grid, so `{min: 0.25, max: 9.75, step: 0.5}` prints ticks at 2.6 and 7.4 where its own scale has 2.75 and 7.25.

This adds `step_from_min` (data attribute `data-step-from-min`), a boolean that defaults to false. Turn it on and every value becomes `min` plus a whole number of steps, so the scale reads 0.5, 1.5, 2.5 and still ends at `max`. Handles, the input value, the keyboard and the grid labels all follow that scale. An initial value already on it is left alone; one that is off it moves to the nearest point at first paint, the same way a drag would land there.

One thing to know before turning it on: handle limits and intervals are compared exactly, but the position they hand back is then rounded onto the scale like any other value, so a `from_max` of 5 on the 0.5, 1.5, 2.5 scale stops the handle at 5.5. The readme row asks you to put limits and intervals on the scale. The default path has the same behavior for integer steps today, and a separate issue tracks making limits stop exactly where they are set.

The option is opt-in because switching the scale by default would move values for anyone using a config such as `{min: 0.01, step: 1}` to keep zero out of the range: 1, 2, 3 would become 1.01, 2.01, 3.01. With the option off the arithmetic is untouched, including the rounding for fractional minimums added in 2.4.2 for issue #760.

Both sides of the switch are covered by new tests. The unit tests pin the new scale for five reported configurations, the grid labels with and without `grid_snap`, the data attribute in both directions, the limit behavior described above, and the 2.4.2 values for the same configurations with the option off. The browser tests drive it through real layout: an initial 2.5 that survives first paint and `update()`, a mouse drag landing on a half value, arrow keys walking 1.01, 2.01, 3.01 up from a 0.01 minimum, and grid labels on the new scale, with the initial value case also pinned with the option off. The existing suites are unchanged and green, the precision tests from #760 included.

Refs #869
