### PR TITLE
Add values_raw to keep custom values exactly as given (#505)

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -443,19 +443,6 @@
         };
         config_from_data.values = config_from_data.values && config_from_data.values.split(",");
 
-        // #505: data-values is a comma-separated string, so "10, 20, 30" carries
-        // a leading space into every entry after the first. values_raw keeps a
-        // values entry exactly as given everywhere else, so the split entries
-        // are trimmed only when it is on; a JS values array is never touched
-        // here, only what came from the comma split. data-values-raw (checked
-        // first) overrides a JS values_raw option, matching every other data-*
-        // attribute in this constructor.
-        if (config_from_data.values && (config_from_data.values_raw !== undefined ? config_from_data.values_raw : options.values_raw)) {
-            for (i = 0; i < config_from_data.values.length; i++) {
-                config_from_data.values[i] = config_from_data.values[i].replace(/^\s+|\s+$/g, "");
-            }
-        }
-
         for (prop in config_from_data) {
             if (config_from_data.hasOwnProperty(prop)) {
                 // #681: for every other option "" means "not set", but for
@@ -497,6 +484,22 @@
 
         // data config extends config
         $.extend(config, config_from_data);
+
+        // #505: data-values is a comma-separated string, so "10, 20, 30"
+        // carries a leading space into every entry after the first. With
+        // values_raw on those spaces would reach from_value, the input and
+        // the labels, so the split entries are trimmed here, once the option
+        // has been resolved from the data attribute and the JS option in the
+        // usual order (an empty data-values-raw attribute means "not set",
+        // like every other data-* option). A JS values array is never
+        // touched: only entries that came from the comma split are trimmed,
+        // and only when values_raw is on.
+        if (config_from_data.values && config.values_raw) {
+            for (i = 0; i < config.values.length; i++) {
+                config.values[i] = config.values[i].replace(/^\s+|\s+$/g, "");
+            }
+        }
+
         this.options = config;
 
 
@@ -2655,6 +2658,9 @@
                     // number. Entries that are already numbers are exempt, so
                     // values: [1000, 2000] still gets the thousands-separator
                     // prettify below whether values_raw is on or off.
+                    // Turning values_raw on later through update() cannot restore
+                    // entries this loop has already converted, because the clone
+                    // holds numbers by then; pass values again in the same update() call.
                     if (o.values_raw && typeof v[i] !== "number") {
                         value = NaN;
                     } else {

--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -295,7 +295,7 @@
          */
         var $inp = this.$cache.input,
             val = $inp.prop("value"),
-            config, config_from_data, prop;
+            config, config_from_data, prop, i;
 
         // default config
         config = {
@@ -314,6 +314,7 @@
             drag_over_limit: false,
 
             values: [],
+            values_raw: false,
             p_values: [],
 
             from_fixed: false,
@@ -394,6 +395,7 @@
             drag_over_limit: $inp.data("dragOverLimit"),
 
             values: $inp.data("values"),
+            values_raw: $inp.data("valuesRaw"),
 
             from_fixed: $inp.data("fromFixed"),
             from_min: $inp.data("fromMin"),
@@ -440,6 +442,19 @@
             extra_classes: $inp.data("extraClasses")
         };
         config_from_data.values = config_from_data.values && config_from_data.values.split(",");
+
+        // #505: data-values is a comma-separated string, so "10, 20, 30" carries
+        // a leading space into every entry after the first. values_raw keeps a
+        // values entry exactly as given everywhere else, so the split entries
+        // are trimmed only when it is on; a JS values array is never touched
+        // here, only what came from the comma split. data-values-raw (checked
+        // first) overrides a JS values_raw option, matching every other data-*
+        // attribute in this constructor.
+        if (config_from_data.values && (config_from_data.values_raw !== undefined ? config_from_data.values_raw : options.values_raw)) {
+            for (i = 0; i < config_from_data.values.length; i++) {
+                config_from_data.values[i] = config_from_data.values[i].replace(/^\s+|\s+$/g, "");
+            }
+        }
 
         for (prop in config_from_data) {
             if (config_from_data.hasOwnProperty(prop)) {
@@ -2635,7 +2650,16 @@
                 o.grid_snap = true;
 
                 for (i = 0; i < vl; i++) {
-                    value = +v[i];
+                    // #505: values_raw keeps a values entry exactly as given
+                    // instead of converting a numeric-looking string to a
+                    // number. Entries that are already numbers are exempt, so
+                    // values: [1000, 2000] still gets the thousands-separator
+                    // prettify below whether values_raw is on or off.
+                    if (o.values_raw && typeof v[i] !== "number") {
+                        value = NaN;
+                    } else {
+                        value = +v[i];
+                    }
 
                     if (!isNaN(value)) {
                         v[i] = value;

--- a/readme.md
+++ b/readme.md
@@ -133,7 +133,7 @@ Or use `data-*` attributes on the input:
 | `drag_interval` | `data-drag-interval` | `false` | boolean | Allow dragging the whole range. Double type only |
 | `drag_over_limit` | `data-drag-over-limit` | `false` | boolean | Let a dragged handle push the other handle instead of stopping at it. Mouse/touch drag only, respects min_interval, max_interval, from_fixed and to_fixed. Double type only |
 | `values` | `data-values` | `[]` | array | Custom array of possible values (numbers or strings). When set, min, max and step are ignored. Numeric-looking strings are converted to numbers unless `values_raw` is set |
-| `values_raw` | `data-values-raw` | `false` | boolean | Keep `values` entries exactly as given: "20.0" stays "20.0" in `from_value`, in the value written to the input and on the label. By default numeric-looking strings are converted to numbers ("20.0" becomes 20). Spaces around the commas in `data-values` are ignored when this is on. Set it when creating the slider, or pass `values` again in the same `update()` call |
+| `values_raw` | `data-values-raw` | `false` | boolean | Keep `values` entries exactly as given: "20.0" stays "20.0" in `from_value`/`to_value`, in the value written to the input and on the label. By default numeric-looking strings are converted to numbers ("20.0" becomes 20). Spaces around the commas in `data-values` are ignored when this is on. Set it when creating the slider, or pass `values` again in the same `update()` call |
 | `from_fixed` | `data-from-fixed` | `false` | boolean | Fix position of left (or single) handle |
 | `from_min` | `data-from-min` | `min` | number | Minimum limit for left (or single) handle |
 | `from_max` | `data-from-max` | `max` | number | Maximum limit for left (or single) handle |

--- a/readme.md
+++ b/readme.md
@@ -133,7 +133,7 @@ Or use `data-*` attributes on the input:
 | `drag_interval` | `data-drag-interval` | `false` | boolean | Allow dragging the whole range. Double type only |
 | `drag_over_limit` | `data-drag-over-limit` | `false` | boolean | Let a dragged handle push the other handle instead of stopping at it. Mouse/touch drag only, respects min_interval, max_interval, from_fixed and to_fixed. Double type only |
 | `values` | `data-values` | `[]` | array | Custom array of possible values (numbers or strings). When set, min, max and step are ignored. Numeric-looking strings are converted to numbers unless `values_raw` is set |
-| `values_raw` | `data-values-raw` | `false` | boolean | Keep `values` entries exactly as given: "20.0" stays "20.0" in `from_value`, in the input and on the label. By default numeric-looking strings are converted to numbers ("20.0" becomes 20). `data-values` entries are trimmed when this is on |
+| `values_raw` | `data-values-raw` | `false` | boolean | Keep `values` entries exactly as given: "20.0" stays "20.0" in `from_value`, in the value written to the input and on the label. By default numeric-looking strings are converted to numbers ("20.0" becomes 20). Spaces around the commas in `data-values` are ignored when this is on. Set it when creating the slider, or pass `values` again in the same `update()` call |
 | `from_fixed` | `data-from-fixed` | `false` | boolean | Fix position of left (or single) handle |
 | `from_min` | `data-from-min` | `min` | number | Minimum limit for left (or single) handle |
 | `from_max` | `data-from-max` | `max` | number | Maximum limit for left (or single) handle |

--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,8 @@ Or use `data-*` attributes on the input:
 | `max_interval` | `data-max-interval` | `-` | number | Maximum range between handles. Double type only |
 | `drag_interval` | `data-drag-interval` | `false` | boolean | Allow dragging the whole range. Double type only |
 | `drag_over_limit` | `data-drag-over-limit` | `false` | boolean | Let a dragged handle push the other handle instead of stopping at it. Mouse/touch drag only, respects min_interval, max_interval, from_fixed and to_fixed. Double type only |
-| `values` | `data-values` | `[]` | array | Custom array of possible values (numbers or strings). When set, min, max and step are ignored |
+| `values` | `data-values` | `[]` | array | Custom array of possible values (numbers or strings). When set, min, max and step are ignored. Numeric-looking strings are converted to numbers unless `values_raw` is set |
+| `values_raw` | `data-values-raw` | `false` | boolean | Keep `values` entries exactly as given: "20.0" stays "20.0" in `from_value`, in the input and on the label. By default numeric-looking strings are converted to numbers ("20.0" becomes 20). `data-values` entries are trimmed when this is on |
 | `from_fixed` | `data-from-fixed` | `false` | boolean | Fix position of left (or single) handle |
 | `from_min` | `data-from-min` | `min` | number | Minimum limit for left (or single) handle |
 | `from_max` | `data-from-max` | `max` | number | Maximum limit for left (or single) handle |
@@ -205,7 +206,9 @@ When the `values` option is used, `from` and `to` hold the index of the selected
 entry in the `values` array, not the entry itself. `from_value` and `to_value`
 hold the actual entry at that index. In this mode `min` and `max` hold the
 first and last index of the `values` array, and `min_pretty`/`max_pretty` hold
-the label text of those entries.
+the label text of those entries. By default a numeric-looking entry like
+"20.0" comes back as the number 20; set `values_raw` to keep it as the string
+"20.0" instead.
 
 
 ## Public methods

--- a/test/browser/values-raw.spec.mjs
+++ b/test/browser/values-raw.spec.mjs
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+import { open, events, input, drag, LABEL } from './helpers.mjs';
+
+// Real-browser coverage for #505: "values: ['17.5', '12.2b', '20.0']" silently
+// turned the last entry into the number 20 everywhere a user can see it (the
+// bubble, the min/max labels, the input's posted value, every callback
+// payload), so a backend matching against its own "20.0" string never found
+// it. values_raw (default false, so every existing setup renders
+// byte-identical to before) keeps a values entry exactly as given instead.
+// The jsdom unit suite (test/unit/values-raw.test.mjs) already covers the
+// option-state side of this; these tests exercise the same fix through
+// actual layout, a real pointer drag and the render loop, which the unit
+// suite cannot reach.
+
+test.describe(`values_raw coverage (${LABEL})`, () => {
+  // Mutation this catches: dropping the `o.values_raw && typeof v[i] !==
+  // "number"` guard from validate()'s values loop (js/ion.rangeSlider.js) --
+  // the bubble, the max label, the input and the onStart payload would all
+  // read "20" instead of "20.0".
+  test('values_raw keeps the raw entry on the bubble, the max label, the input and the onStart payload (#505)', async ({ page }) => {
+    await open(page, { values: ['17.5', '12.2b', '20.0'], from: 2, values_raw: true });
+
+    await expect(page.locator('.irs-single')).toHaveText('20.0');
+    await expect(page.locator('.irs-max')).toHaveText('20.0');
+    await expect(input(page)).toHaveValue('20.0');
+
+    const ev = await events(page);
+    const startEv = ev.find((e) => e.type === 'onStart');
+    expect(startEv, 'onStart must have fired').toBeTruthy();
+    expect(startEv.from_value).toBe('20.0');
+  });
+
+  // Same config, but the raw entry is reached through a real drag instead of
+  // init -- catches a fix that only patches the initial render (e.g. one
+  // that special-cases init() instead of fixing validate()/writeToInput()
+  // for every render).
+  test('a real drag to the first entry keeps it raw too, not only at init (#505)', async ({ page }) => {
+    await open(page, { values: ['17.5', '12.2b', '20.0'], from: 2, values_raw: true });
+
+    // from starts at index 2 (100% along the line, 3 values 0-2, step 1); a
+    // leftward move past the 25% mark (the index 0/1 rounding boundary)
+    // lands on index 0. Kept short of a full-line overshoot so the pointer
+    // release stays on screen -- Playwright's Firefox driver drops the
+    // mouseup (and with it onFinish) when it lands off-viewport.
+    await drag(page, '.irs-handle.single', -0.9);
+
+    await expect(page.locator('.irs-single')).toHaveText('17.5');
+    await expect(input(page)).toHaveValue('17.5');
+
+    const ev = await events(page);
+    const finishEv = ev.find((e) => e.type === 'onFinish');
+    expect(finishEv, 'onFinish must have fired').toBeTruthy();
+    expect(finishEv.from_value).toBe('17.5');
+  });
+
+  // Characterization: values_raw defaults to false, so this must render
+  // exactly like 2.4.2. Mutation this catches: inverting the `o.values_raw`
+  // guard (js/ion.rangeSlider.js) -- the bubble/label/input would read
+  // "20.0" and from_value would come back as the string "20.0" here too.
+  test('values_raw off (the default) still converts the numeric-looking entry to a number (#505)', async ({ page }) => {
+    await open(page, { values: ['17.5', '12.2b', '20.0'], from: 2 });
+
+    await expect(page.locator('.irs-single')).toHaveText('20');
+    await expect(input(page)).toHaveValue('20');
+
+    const ev = await events(page);
+    const startEv = ev.find((e) => e.type === 'onStart');
+    expect(startEv, 'onStart must have fired').toBeTruthy();
+    expect(startEv.from_value).toBe(20);
+  });
+
+  // Same assertions as the first test, through the data-* attribute route
+  // instead of the JS config object. Mutation this catches: removing the
+  // `values_raw: $inp.data("valuesRaw")` line from config_from_data
+  // (js/ion.rangeSlider.js) -- data-values-raw would be silently ignored and
+  // this would render "20" like the values_raw-off test above.
+  test('data-values-raw="true" with data-values and data-from produces the same raw entry (#505)', async ({ page }) => {
+    await open(page, {}, {
+      attrs: JSON.stringify({ 'data-values': '17.5,12.2b,20.0', 'data-values-raw': 'true', 'data-from': '2' })
+    });
+
+    await expect(page.locator('.irs-single')).toHaveText('20.0');
+    await expect(page.locator('.irs-max')).toHaveText('20.0');
+    await expect(input(page)).toHaveValue('20.0');
+
+    const ev = await events(page);
+    const startEv = ev.find((e) => e.type === 'onStart');
+    expect(startEv, 'onStart must have fired').toBeTruthy();
+    expect(startEv.from_value).toBe('20.0');
+  });
+});

--- a/test/browser/values-raw.spec.mjs
+++ b/test/browser/values-raw.spec.mjs
@@ -17,7 +17,7 @@ test.describe(`values_raw coverage (${LABEL})`, () => {
   // "number"` guard from validate()'s values loop (js/ion.rangeSlider.js) --
   // the bubble, the max label, the input, the onStart payload and the grid
   // labels would all read "20" instead of "20.0".
-  test('values_raw keeps the raw entry on the bubble, the max label, the input and the onStart payload (#505)', async ({ page }) => {
+  test('values_raw keeps the raw entry on the bubble, the max label, the grid labels, the input and the onStart payload (#505)', async ({ page }) => {
     await open(page, { values: ['17.5', '12.2b', '20.0'], from: 2, values_raw: true, grid: true });
 
     await expect(page.locator('.irs-single')).toHaveText('20.0');

--- a/test/browser/values-raw.spec.mjs
+++ b/test/browser/values-raw.spec.mjs
@@ -15,14 +15,20 @@ import { open, events, input, drag, LABEL } from './helpers.mjs';
 test.describe(`values_raw coverage (${LABEL})`, () => {
   // Mutation this catches: dropping the `o.values_raw && typeof v[i] !==
   // "number"` guard from validate()'s values loop (js/ion.rangeSlider.js) --
-  // the bubble, the max label, the input and the onStart payload would all
-  // read "20" instead of "20.0".
+  // the bubble, the max label, the input, the onStart payload and the grid
+  // labels would all read "20" instead of "20.0".
   test('values_raw keeps the raw entry on the bubble, the max label, the input and the onStart payload (#505)', async ({ page }) => {
-    await open(page, { values: ['17.5', '12.2b', '20.0'], from: 2, values_raw: true });
+    await open(page, { values: ['17.5', '12.2b', '20.0'], from: 2, values_raw: true, grid: true });
 
     await expect(page.locator('.irs-single')).toHaveText('20.0');
     await expect(page.locator('.irs-max')).toHaveText('20.0');
     await expect(input(page)).toHaveValue('20.0');
+
+    // Values mode snaps the grid to one tick per entry (validate() derives
+    // grid_num/grid_snap from the values array), so the grid must carry the
+    // same raw entries as the bubble/label/input above, in order.
+    const gridTexts = await page.locator('.irs-grid-text').allTextContents();
+    expect(gridTexts).toEqual(['17.5', '12.2b', '20.0']);
 
     const ev = await events(page);
     const startEv = ev.find((e) => e.type === 'onStart');

--- a/test/unit/values-raw.test.mjs
+++ b/test/unit/values-raw.test.mjs
@@ -1,0 +1,136 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSlider, plain } from './helpers.mjs';
+
+// #505: "values: ['17.5', '12.2b', '20.0']" silently turned the last entry
+// into the number 20 (in options.values, result.from_value/to_value, the
+// input's posted value and the labels), so a backend matching against its
+// own "20.0" string could never find it. values_raw (default false, so
+// every existing data-values/JS-values setup is byte-identical) keeps a
+// values entry exactly as given instead of converting a numeric-looking
+// string to a number. jsdom has no layout (see helpers.mjs): calc() bails
+// before it ever reaches the values-mode from_value/to_value assignment, so
+// every from_value/to_value/input-value assertion below drives update() (or
+// reset()) first, the way values-mode-result.test.mjs's update() test does,
+// to run updateResult() without needing real geometry.
+
+test('values_raw keeps a values entry exactly as given -- the numeric guard converts "20.0" to the number 20 without it (#505)', (t) => {
+  const values = ['17.5', '12.2b', '20.0'];
+  const { slider } = createSlider(t, '<input>', { values: values, values_raw: true, from: 2 });
+
+  assert.deepEqual(plain(slider.options.values), values);
+
+  slider.update({ from: 2 });
+  assert.equal(slider.result.from_value, '20.0');
+  assert.equal(typeof slider.result.from_value, 'string');
+});
+
+test('values_raw off is byte-identical to 2.4.2 -- numeric-looking strings still convert to numbers (characterization; mutation: invert the o.values_raw guard) (#505)', (t) => {
+  const { slider } = createSlider(t, '<input>', { values: ['17.5', '12.2b', '20.0'], from: 2 });
+
+  assert.deepEqual(plain(slider.options.values), [17.5, '12.2b', 20]);
+
+  slider.update({ from: 2 });
+  assert.equal(slider.result.from_value, 20);
+  assert.equal(typeof slider.result.from_value, 'number');
+});
+
+test('values_raw keeps p_values entries as given -- without the guard p_values is still built from +v[i] (#505)', (t) => {
+  const { slider } = createSlider(t, '<input>', { values: ['17.5', '12.2b', '20.0'], values_raw: true, from: 2 });
+
+  assert.deepEqual(plain(slider.options.p_values), ['17.5', '12.2b', '20.0']);
+
+  slider.update({ from: 2 });
+  assert.equal(slider.result.from_pretty, '20.0');
+});
+
+test('values_raw exempts entries that are already numbers -- characterization, green with or without values_raw; the typeof check is what makes it stay green (mutation: drop `typeof v[i] !== "number"` from the guard, keeping only `o.values_raw`) (#505)', (t) => {
+  const { slider } = createSlider(t, '<input>', { values: [1000, 2000], values_raw: true, from: 0 });
+
+  assert.deepEqual(plain(slider.options.p_values), ['1 000', '2 000']);
+
+  slider.update({ from: 0 });
+  assert.equal(slider.result.from_pretty, '1 000');
+});
+
+test('values_raw does not bypass prettify_all_values -- a raw string entry reaches a custom prettify only when it is explicitly on (#505)', (t) => {
+  const seen_off = [];
+  createSlider(t, '<input>', {
+    values: ['17.5', '12.2b', '20.0'],
+    values_raw: true,
+    prettify: (n) => { seen_off.push(n); return n; }
+  });
+  assert.deepEqual(seen_off, [], 'no raw string entry may reach a custom prettify by default');
+
+  const seen_on = [];
+  createSlider(t, '<input>', {
+    values: ['17.5', '12.2b', '20.0'],
+    values_raw: true,
+    prettify_all_values: true,
+    prettify: (n) => { seen_on.push(n); return n; }
+  });
+  assert.deepEqual(seen_on, ['17.5', '12.2b', '20.0']);
+});
+
+test('data-values-raw maps to values_raw, matching every other data-* attribute in the constructor (#505)', (t) => {
+  const { slider } = createSlider(t, '<input data-values="17.5,12.2b,20.0" data-values-raw="true" data-from="2">', {});
+  assert.equal(slider.options.values_raw, true);
+
+  slider.update({ from: 2 });
+  assert.equal(slider.result.from_value, '20.0');
+});
+
+test('data-values-raw="false" overrides a JS values_raw: true option (#505)', (t) => {
+  const { slider } = createSlider(t, '<input data-values="17.5,12.2b,20.0" data-values-raw="false" data-from="2">', { values_raw: true });
+  assert.equal(slider.options.values_raw, false);
+
+  slider.update({ from: 2 });
+  assert.equal(slider.result.from_value, 20);
+  assert.equal(typeof slider.result.from_value, 'number');
+});
+
+test('update() and reset() keep a raw entry raw -- validate() runs again on each, and a re-conversion would turn "20.0" back into a number the second time (#505)', (t) => {
+  const { slider } = createSlider(t, '<input>', { values: ['17.5', '12.2b', '20.0'], values_raw: true, from: 2 });
+
+  slider.update({ from: 0 });
+  assert.equal(slider.result.from_value, '17.5');
+
+  slider.update({ from: 2 });
+  assert.equal(slider.result.from_value, '20.0');
+
+  // reset() re-runs update() with no arguments, so it re-validates against
+  // whatever options.from currently is (2, set by the update() call above,
+  // not the from: 2 passed at construction -- see smoke.spec.mjs's "update()
+  // rewrites the options, reset() returns to them" contract).
+  slider.reset();
+  assert.equal(slider.result.from_value, '20.0');
+});
+
+test('values_raw trims data-values entries split on the comma (#505)', (t) => {
+  const { slider } = createSlider(t, '<input data-values="10, 20, 30" data-values-raw="true" data-from="0">', {});
+  assert.deepEqual(plain(slider.options.values), ['10', '20', '30']);
+
+  slider.update({ from: 0 });
+  assert.equal(slider.result.from_value, '10');
+});
+
+test('values_raw never trims a JS values array -- only data-values entries come from a comma split (#505)', (t) => {
+  const { slider } = createSlider(t, '<input>', { values: [' 5 '], values_raw: true, from: 0 });
+  assert.deepEqual(plain(slider.options.values), [' 5 ']);
+});
+
+test("the input's value is the raw entry when values_raw is on -- writeToInput must not read a converted copy (#505)", (t) => {
+  const { slider, $input } = createSlider(t, '<input>', { values: ['17.5', '12.2b', '20.0'], values_raw: true, from: 2 });
+
+  slider.update({ from: 2 });
+  assert.equal($input.val(), '20.0');
+});
+
+test("the input's value in double mode joins both raw entries with input_values_separator when values_raw is on (#505)", (t) => {
+  const { slider, $input } = createSlider(t, '<input>', {
+    type: 'double', values: ['17.5', '12.2b', '20.0'], values_raw: true, from: 0, to: 2
+  });
+
+  slider.update({ from: 0, to: 2 });
+  assert.equal($input.val(), '17.5;20.0');
+});

--- a/test/unit/values-raw.test.mjs
+++ b/test/unit/values-raw.test.mjs
@@ -134,3 +134,25 @@ test("the input's value in double mode joins both raw entries with input_values_
   slider.update({ from: 0, to: 2 });
   assert.equal($input.val(), '17.5;20.0');
 });
+
+test('a JS values_raw option trims data-values when no data-values-raw attribute is present -- the resolved-option gate must still fall back to the JS option, the way the old ternary did (mutation: replace `config.values_raw` in the new gate with `config_from_data.values_raw`) (#505)', (t) => {
+  const { slider } = createSlider(t, '<input data-values="10, 20, 30">', { values_raw: true });
+  assert.deepEqual(plain(slider.options.values), ['10', '20', '30']);
+
+  slider.update({ from: 0 });
+  assert.equal(slider.result.from_value, '10');
+});
+
+test('an empty data-values-raw attribute is "not set" and falls back to a JS values_raw: true option, matching every other data-* attribute -- RED on HEAD bd35676, where the trim ran before the empty-string strip and so saw "" as an explicit off, leaving " 20"/" 30" untrimmed (#505)', (t) => {
+  const { slider } = createSlider(t, '<input data-values="10, 20, 30" data-values-raw="">', { values_raw: true });
+  assert.equal(slider.options.values_raw, true);
+  assert.deepEqual(plain(slider.options.values), ['10', '20', '30']);
+});
+
+test('the no-argument init path -- options undefined at construction still resolves values_raw and trims/keeps entries the same as passing {} (characterization; mutation: remove `options = options || {};` near the top of the constructor -- with a value attribute present, the constructor reaches the unguarded `options.input_values_separator` read and throws a TypeError) (#505)', (t) => {
+  const { slider } = createSlider(t, '<input value="2" data-values="17.5,12.2b,20.0" data-values-raw="true" data-from="2">');
+  assert.equal(slider.options.values_raw, true);
+
+  slider.update({ from: 2 });
+  assert.equal(slider.result.from_value, '20.0');
+});


### PR DESCRIPTION
The `values` option replaces the numeric range with a fixed list of entries, such as sizes or version numbers. Until now an entry that looked like a number, "20.0" for instance, quietly became the number 20 wherever the slider reported it: in the `from_value` and `to_value` fields handed to callbacks, in the value written to the input for the form, and on the label. A backend matching that value against its own list of strings never found "20.0" there.

This adds `values_raw` (data attribute `data-values-raw`), a boolean that defaults to false. Turn it on and an entry comes back exactly as it was given, so "20.0" stays "20.0". Entries that are already JavaScript numbers are not affected, so an array of real numbers still gets the thousands separator it always had. When the entries come from a `data-values` attribute, the spaces around the commas are ignored while the option is on, so "10, 20, 30" does not carry a stray space into "20". Set the option when the slider is created, or pass `values` again in the same `update()` call: an entry that was already converted at creation cannot be restored by toggling the option later.

With `values_raw` left at its default, entries convert to numbers exactly as before, so pages relying on `data-values="1,2,3"` handing back numbers keep working unchanged. Reading a pre-filled `value` attribute back into a list of string entries at creation is a separate change and stays out of this one.

Unit tests cover the JavaScript array and the `data-values` attribute, single and double mode, `update()` and `reset()`, the trimming rule with and without the attribute form, the no-arguments initialization path, and the interplay with `prettify_all_values`. Browser tests in Chromium, Firefox and WebKit check the bubble, the max label, the grid labels, the input value and the callback payload, at first paint and after a real drag, with the default behavior pinned alongside.

Refs #505
